### PR TITLE
Local customizations: Ollama translate tuning, SenseVoice, BS-RoFormer rewrite, batched faster-whisper

### DIFF
--- a/whisperjav/config/builder.py
+++ b/whisperjav/config/builder.py
@@ -1,0 +1,204 @@
+"""
+PipelineBuilder for WhisperJAV Configuration System v2.0.
+
+Fluent API for building custom pipeline configurations.
+"""
+
+from copy import deepcopy
+from typing import Any, Dict, Optional
+
+from .errors import ConfigValidationError
+from .resolver import resolve_config
+from .schemas import Sensitivity
+
+
+class PipelineBuilder:
+    """
+    Fluent builder for pipeline configurations.
+
+    Example:
+        >>> config = (
+        ...     PipelineBuilder("balanced")
+        ...     .with_sensitivity("aggressive")
+        ...     .with_task("translate")
+        ...     .with_decoder_param("beam_size", 10)
+        ...     .build()
+        ... )
+    """
+
+    def __init__(self, pipeline_name: str):
+        """
+        Initialize builder with a base pipeline.
+
+        Args:
+            pipeline_name: Base pipeline ('faster', 'fast', 'fidelity', 'balanced')
+        """
+        self._pipeline_name = pipeline_name
+        self._sensitivity = "balanced"
+        self._task = "transcribe"
+        self._decoder_overrides: Dict[str, Any] = {}
+        self._provider_overrides: Dict[str, Any] = {}
+        self._vad_overrides: Dict[str, Any] = {}
+        self._feature_overrides: Dict[str, Any] = {}
+        self._kwargs: Dict[str, Any] = {}
+
+    def with_sensitivity(self, sensitivity: str) -> "PipelineBuilder":
+        """Set sensitivity level."""
+        # Validate
+        try:
+            Sensitivity(sensitivity)
+        except ValueError:
+            valid = [s.value for s in Sensitivity]
+            raise ConfigValidationError(
+                f"Invalid sensitivity. Must be one of: {valid}",
+                field="sensitivity",
+                value=sensitivity
+            )
+        self._sensitivity = sensitivity
+        return self
+
+    def with_task(self, task: str) -> "PipelineBuilder":
+        """Set task (transcribe or translate)."""
+        if task not in ("transcribe", "translate"):
+            raise ConfigValidationError(
+                "Task must be 'transcribe' or 'translate'",
+                field="task",
+                value=task
+            )
+        self._task = task
+        return self
+
+    def with_decoder_param(self, name: str, value: Any) -> "PipelineBuilder":
+        """Override a decoder parameter."""
+        self._decoder_overrides[name] = value
+        return self
+
+    def with_provider_param(self, name: str, value: Any) -> "PipelineBuilder":
+        """Override a provider parameter."""
+        self._provider_overrides[name] = value
+        return self
+
+    def with_vad_param(self, name: str, value: Any) -> "PipelineBuilder":
+        """Override a VAD parameter."""
+        self._vad_overrides[name] = value
+        return self
+
+    def with_beam_size(self, size: int) -> "PipelineBuilder":
+        """Set decoder beam size."""
+        return self.with_decoder_param("beam_size", size)
+
+    def with_patience(self, patience: float) -> "PipelineBuilder":
+        """Set decoder patience."""
+        return self.with_decoder_param("patience", patience)
+
+    def with_temperature(self, temperature: float) -> "PipelineBuilder":
+        """Set provider temperature."""
+        return self.with_provider_param("temperature", temperature)
+
+    def with_no_speech_threshold(self, threshold: float) -> "PipelineBuilder":
+        """Set no speech threshold."""
+        return self.with_provider_param("no_speech_threshold", threshold)
+
+    def with_vad_threshold(self, threshold: float) -> "PipelineBuilder":
+        """Set VAD threshold."""
+        return self.with_vad_param("threshold", threshold)
+
+    def with_scene_detection_method(self, method: str) -> "PipelineBuilder":
+        """Set scene detection method."""
+        self._kwargs["scene_detection_method"] = method
+        return self
+
+    def with_feature(self, feature_name: str, config: Dict[str, Any]) -> "PipelineBuilder":
+        """Override feature configuration."""
+        self._feature_overrides[feature_name] = config
+        return self
+
+    def build(self) -> Dict[str, Any]:
+        """
+        Build and return the final configuration.
+
+        Returns:
+            Resolved configuration dictionary.
+
+        Raises:
+            ConfigValidationError: If configuration is invalid.
+        """
+        # Get base config from resolver
+        config = resolve_config(
+            self._pipeline_name,
+            self._sensitivity,
+            self._task,
+            **self._kwargs
+        )
+
+        # Apply overrides
+        if self._decoder_overrides:
+            config['params']['decoder'].update(self._decoder_overrides)
+
+        if self._provider_overrides:
+            config['params']['provider'].update(self._provider_overrides)
+
+        if self._vad_overrides:
+            config['params']['vad'].update(self._vad_overrides)
+
+        if self._feature_overrides:
+            for feature_name, feature_config in self._feature_overrides.items():
+                if feature_name in config['features']:
+                    config['features'][feature_name].update(feature_config)
+                else:
+                    config['features'][feature_name] = feature_config
+
+        return config
+
+    def copy(self) -> "PipelineBuilder":
+        """Create a copy of this builder."""
+        new_builder = PipelineBuilder(self._pipeline_name)
+        new_builder._sensitivity = self._sensitivity
+        new_builder._task = self._task
+        new_builder._decoder_overrides = deepcopy(self._decoder_overrides)
+        new_builder._provider_overrides = deepcopy(self._provider_overrides)
+        new_builder._vad_overrides = deepcopy(self._vad_overrides)
+        new_builder._feature_overrides = deepcopy(self._feature_overrides)
+        new_builder._kwargs = deepcopy(self._kwargs)
+        return new_builder
+
+
+def quick_config(
+    pipeline: str = "balanced",
+    sensitivity: str = "balanced",
+    task: str = "transcribe",
+    **overrides
+) -> Dict[str, Any]:
+    """
+    Quick configuration helper for simple use cases.
+
+    Args:
+        pipeline: Pipeline name
+        sensitivity: Sensitivity level
+        task: Task type
+        **overrides: Parameter overrides (beam_size, patience, temperature, etc.)
+
+    Returns:
+        Resolved configuration dictionary.
+
+    Example:
+        >>> config = quick_config("balanced", "aggressive", beam_size=10)
+    """
+    builder = PipelineBuilder(pipeline).with_sensitivity(sensitivity).with_task(task)
+
+    # Map common overrides
+    decoder_params = {'beam_size', 'patience', 'best_of', 'language'}
+    provider_params = {'temperature', 'no_speech_threshold', 'compression_ratio_threshold'}
+    vad_params = {'threshold', 'min_speech_duration_ms', 'speech_pad_ms'}
+
+    for key, value in overrides.items():
+        if key in decoder_params:
+            builder.with_decoder_param(key, value)
+        elif key in provider_params:
+            builder.with_provider_param(key, value)
+        elif key in vad_params:
+            builder.with_vad_param(key, value)
+        elif key == 'scene_detection_method':
+            builder.with_scene_detection_method(value)
+
+    return builder.build()

--- a/whisperjav/config/resolver.py
+++ b/whisperjav/config/resolver.py
@@ -1,0 +1,392 @@
+"""
+Configuration Resolver for WhisperJAV Configuration System v2.0.
+
+Main entry point: resolve_config() produces output identical to
+TranscriptionTuner.resolve_params() for backward compatibility.
+"""
+
+import json
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict
+
+from .errors import ConfigValidationError, UnknownComponentError
+
+logger = logging.getLogger("whisperjav")
+from .schemas import (
+    DECODER_PRESETS,
+    FASTER_WHISPER_ENGINE_PRESETS,
+    HALLUCINATION_THRESHOLDS,
+    MODELS,
+    SILERO_VAD_PRESETS,
+    STABLE_TS_ENGINE_OPTIONS,
+    STABLE_TS_VAD_PRESETS,
+    TRANSCRIBER_PRESETS,
+    Sensitivity,
+)
+
+
+# Backend-specific type conversions
+INTEGER_PARAMS_STABLE_TS = {
+    'beam_size', 'best_of', 'batch_size', 'max_new_tokens',
+    'language_detection_segments', 'ts_num', 'q_levels', 'k_size',
+    'no_repeat_ngram_size',
+}
+
+FLOAT_PARAMS = {
+    'patience', 'length_penalty', 'repetition_penalty',
+    'compression_ratio_threshold', 'logprob_threshold', 'logprob_margin',
+    'no_speech_threshold', 'vad_threshold', 'max_instant_words',
+    'hallucination_silence_threshold', 'nonspeech_error',
+}
+
+
+def resolve_config(
+    pipeline_name: str,
+    sensitivity: str = "balanced",
+    task: str = "transcribe",
+    config_path: Path = None,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Resolve configuration for a pipeline run.
+
+    This is the main entry point for the v2.0 configuration system.
+    Output structure matches TranscriptionTuner.resolve_params() exactly.
+
+    Args:
+        pipeline_name: Pipeline name ('faster', 'fast', 'fidelity', 'balanced')
+        sensitivity: Sensitivity level ('conservative', 'balanced', 'aggressive')
+        task: Task to perform ('transcribe', 'translate')
+        config_path: Optional path to asr_config.json
+        **kwargs: Additional options (e.g., scene_detection_method)
+
+    Returns:
+        Resolved configuration dictionary matching pipeline expectations.
+    """
+    # Load JSON config for pipeline definitions and features
+    config = _load_config(config_path)
+
+    # Validate inputs
+    _validate_inputs(pipeline_name, sensitivity, task, config)
+
+    # Get sensitivity enum
+    sens = Sensitivity(sensitivity)
+
+    # Get pipeline configuration
+    pipeline_cfg = config['pipelines'][pipeline_name]
+    pipeline_map = config['pipeline_parameter_map'][pipeline_name]
+    workflow = deepcopy(pipeline_cfg['workflow'])
+
+    # Build parameters
+    decoder_params = _build_decoder_params(sens, task)
+    provider_params = _build_provider_params(
+        pipeline_name, sens, pipeline_map, config
+    )
+    vad_params = _build_vad_params(sens, pipeline_map, workflow, config)
+
+    # Handle model selection (with task-based override)
+    model_cfg = _resolve_model(pipeline_cfg, workflow, task, config)
+
+    # Extract features
+    features = _extract_features(workflow, config, kwargs)
+
+    # Get backend for type conversion
+    backend = workflow.get('backend', 'whisper')
+
+    # Remove None values and apply type conversions
+    decoder_params = _remove_none_values(decoder_params)
+    provider_params = _remove_none_values(provider_params)
+    vad_params = _remove_none_values(vad_params)
+    features = _remove_none_values(features)
+
+    decoder_params = _convert_types(decoder_params, backend)
+    provider_params = _convert_types(provider_params, backend)
+
+    # Build return structure
+    return {
+        'pipeline_name': pipeline_name,
+        'sensitivity_name': sensitivity,
+        'workflow': workflow,
+        'model': model_cfg,
+        'params': {
+            'decoder': decoder_params,
+            'provider': provider_params,
+            'vad': vad_params,
+        },
+        'features': features,
+        'task': task,
+        'language': decoder_params.get('language', 'ja')
+    }
+
+
+def _load_config(config_path: Path = None) -> Dict[str, Any]:
+    """Load asr_config.json."""
+    if not config_path:
+        config_path = Path(__file__).parent / "asr_config.json"
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"ASR configuration file not found: {config_path}")
+
+    with open(config_path, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+
+    logger.debug(f"v2.0 resolver: Loaded config from {config_path}")
+    return config
+
+
+def _validate_inputs(
+    pipeline_name: str,
+    sensitivity: str,
+    task: str,
+    config: Dict[str, Any]
+) -> None:
+    """Validate input parameters."""
+    # Validate pipeline
+    valid_pipelines = list(config.get('pipeline_parameter_map', {}).keys())
+    if pipeline_name not in valid_pipelines:
+        raise UnknownComponentError("pipeline", pipeline_name, valid_pipelines)
+
+    # Validate sensitivity
+    try:
+        Sensitivity(sensitivity)
+    except ValueError:
+        valid_sens = [s.value for s in Sensitivity]
+        raise ConfigValidationError(
+            f"Invalid sensitivity. Must be one of: {valid_sens}",
+            field="sensitivity",
+            value=sensitivity
+        )
+
+    # Validate task
+    if task not in ("transcribe", "translate"):
+        raise ConfigValidationError(
+            "Task must be 'transcribe' or 'translate'",
+            field="task",
+            value=task
+        )
+
+
+def _build_decoder_params(sens: Sensitivity, task: str) -> Dict[str, Any]:
+    """Build decoder parameters from presets."""
+    preset = DECODER_PRESETS[sens]
+    params = preset.model_dump()
+    params['task'] = task  # Override task
+    return params
+
+
+def _build_provider_params(
+    pipeline_name: str,
+    sens: Sensitivity,
+    pipeline_map: Dict[str, Any],
+    config: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Build provider parameters from presets and config."""
+    provider_params = {}
+
+    # Add transcriber options
+    transcriber = TRANSCRIBER_PRESETS[sens]
+    provider_params.update(transcriber.model_dump())
+
+    # Add engine-specific options based on pipeline
+    engine_sections = pipeline_map.get('engine', [])
+    if isinstance(engine_sections, str):
+        engine_sections = [engine_sections]
+
+    for section_name in engine_sections:
+        if 'faster_whisper_engine' in section_name:
+            engine = FASTER_WHISPER_ENGINE_PRESETS[sens]
+            provider_params.update(engine.model_dump())
+        elif 'stable_ts_engine' in section_name:
+            # Stable-TS options are same across sensitivities
+            provider_params.update(STABLE_TS_ENGINE_OPTIONS.model_dump())
+        elif 'openai_whisper_engine' in section_name:
+            # OpenAI Whisper engine options from JSON
+            if section_name in config and sens.value in config[section_name]:
+                provider_params.update(config[section_name][sens.value])
+        elif 'fast_pipeline_overrides' in section_name:
+            # Fast pipeline overrides from JSON
+            if section_name in config and sens.value in config[section_name]:
+                provider_params.update(config[section_name][sens.value])
+
+    # Add exclusive_whisper_plus_faster if in common sections
+    common_sections = pipeline_map.get('common', [])
+    if isinstance(common_sections, str):
+        common_sections = [common_sections]
+
+    for section_name in common_sections:
+        if 'exclusive_whisper_plus_faster' in section_name:
+            provider_params['hallucination_silence_threshold'] = HALLUCINATION_THRESHOLDS[sens]
+
+    return provider_params
+
+
+def _build_vad_params(
+    sens: Sensitivity,
+    pipeline_map: Dict[str, Any],
+    workflow: Dict[str, Any],
+    config: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Build VAD parameters based on pipeline configuration."""
+    vad_params = {}
+
+    vad_section = pipeline_map.get('vad')
+    vad_handling = pipeline_map.get('vad_handling', 'packed')
+
+    if not vad_section:
+        return vad_params
+
+    # Get VAD options from presets
+    if 'silero_vad' in vad_section:
+        preset = SILERO_VAD_PRESETS[sens]
+        vad_data = preset.model_dump()
+    elif 'stable_ts_vad' in vad_section:
+        preset = STABLE_TS_VAD_PRESETS[sens]
+        vad_data = preset.model_dump()
+    else:
+        # Load from JSON for other VAD types
+        if vad_section in config and sens.value in config[vad_section]:
+            vad_data = deepcopy(config[vad_section][sens.value])
+        else:
+            vad_data = {}
+
+    # Resolve VAD engine repo URL
+    vad_engine_id = workflow.get('vad')
+    if vad_engine_id and vad_engine_id != 'none':
+        if 'vad_engines' in config and vad_engine_id in config['vad_engines']:
+            vad_engine_config = config['vad_engines'][vad_engine_id]
+            vad_data['vad_repo'] = vad_engine_config['repo']
+            vad_data['vad_provider'] = vad_engine_config['provider']
+
+    # Return based on handling type
+    if vad_handling == 'packed':
+        return {}  # VAD params were merged into provider
+    else:
+        return vad_data
+
+
+def _resolve_model(
+    pipeline_cfg: Dict[str, Any],
+    workflow: Dict[str, Any],
+    task: str,
+    config: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Resolve model configuration with task-based override."""
+    model_overrides = pipeline_cfg.get('model_overrides', {})
+    model_id = model_overrides.get(task, workflow['model'])
+
+    if model_id in MODELS:
+        # Use predefined model
+        model = MODELS[model_id]
+        return model.model_dump()
+    elif model_id in config.get('models', {}):
+        # Fall back to JSON config
+        return deepcopy(config['models'][model_id])
+    else:
+        raise ConfigValidationError(
+            f"Model not found: {model_id}",
+            field="model",
+            value=model_id
+        )
+
+
+def _extract_features(
+    workflow: Dict[str, Any],
+    config: Dict[str, Any],
+    kwargs: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Extract feature configurations from workflow."""
+    features = {}
+
+    if 'features' not in workflow:
+        return features
+
+    for feature_name, feature_config in workflow['features'].items():
+        if not feature_config or feature_config == 'none':
+            continue
+
+        if feature_name not in config.get('feature_configs', {}):
+            continue
+
+        if feature_name == 'scene_detection':
+            # Handle scene detection method selection
+            method = kwargs.get('scene_detection_method')
+            if method is None:
+                method = config['feature_configs']['scene_detection'].get(
+                    'default_method', 'auditok'
+                )
+
+            if method in config['feature_configs']['scene_detection']:
+                features[feature_name] = deepcopy(
+                    config['feature_configs']['scene_detection'][method]
+                )
+                features[feature_name]['method'] = method
+            else:
+                # Fallback to auditok
+                features[feature_name] = deepcopy(
+                    config['feature_configs']['scene_detection']['auditok']
+                )
+                features[feature_name]['method'] = 'auditok'
+        else:
+            # Normal feature loading
+            config_key = feature_config if isinstance(feature_config, str) else 'default'
+            if config_key in config['feature_configs'][feature_name]:
+                features[feature_name] = deepcopy(
+                    config['feature_configs'][feature_name][config_key]
+                )
+
+    return features
+
+
+def _remove_none_values(data: Any) -> Any:
+    """Recursively remove None values from dictionary."""
+    if not isinstance(data, dict):
+        return data
+
+    cleaned = {}
+    for key, value in data.items():
+        if value is None:
+            continue
+        elif isinstance(value, dict):
+            cleaned_nested = _remove_none_values(value)
+            if cleaned_nested:
+                cleaned[key] = cleaned_nested
+        elif isinstance(value, list):
+            cleaned[key] = [v for v in value if v is not None]
+        else:
+            cleaned[key] = value
+
+    return cleaned
+
+
+def _convert_types(params: Dict[str, Any], backend: str) -> Dict[str, Any]:
+    """Apply backend-specific type conversions."""
+    if not isinstance(params, dict):
+        return params
+
+    result = params.copy()
+
+    if backend == 'stable-ts':
+        # Convert integer params
+        for param in INTEGER_PARAMS_STABLE_TS:
+            if param in result and result[param] is not None:
+                result[param] = int(result[param])
+
+        # Handle suppress_tokens specially
+        if 'suppress_tokens' in result:
+            val = result['suppress_tokens']
+            if val == -1 or val == "-1":
+                del result['suppress_tokens']
+            elif isinstance(val, (int, str)) and val != -1:
+                try:
+                    result['suppress_tokens'] = [int(val)]
+                except (ValueError, TypeError):
+                    del result['suppress_tokens']
+
+    # Convert float params
+    for param in FLOAT_PARAMS:
+        if param in result and result[param] is not None:
+            result[param] = float(result[param])
+
+    return result

--- a/whisperjav/config/sanitization_config.py
+++ b/whisperjav/config/sanitization_config.py
@@ -20,6 +20,11 @@ class SanitizationConfig:
     enable_fuzzy_matching: bool = True
     enable_repetition_cleaning: bool = True
     enable_cross_subtitle: bool = True
+    # Abnormal-CPS removal (too-fast / too-slow-short-text drop). On by default
+    # to preserve Whisper behavior. Non-autoregressive backends like SenseVoice
+    # span a whole utterance across the scene duration, so genuine short lines
+    # read as "too slow" and get dropped — those backends turn this off.
+    enable_cps_filter: bool = True
     
     # Customizable thresholds
     repetition_threshold: Optional[int] = None

--- a/whisperjav/config/transcription_tuner.py
+++ b/whisperjav/config/transcription_tuner.py
@@ -1,0 +1,565 @@
+"""
+TranscriptionTuner - Configuration resolver for WhisperJAV.
+Implements v4.3 config structure with explicit pipeline parameter mapping.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Union
+from copy import deepcopy
+from whisperjav.utils.logger import logger
+
+
+class TranscriptionTuner:
+    """
+    Configuration resolver for WhisperJAV using v4.3 config structure.
+    Reads configuration and resolves parameters for each pipeline/sensitivity combination.
+    """
+    
+    def __init__(self, config_path: Optional[Path] = None):
+        """
+        Initializes the tuner by loading the configuration file.
+        
+        Args:
+            config_path: Optional path to asr_config.json.
+                        If None, loads default from config directory.
+        """
+        self.config = self._load_config(config_path)
+        self._validate_config_structure()
+    
+    def _load_config(self, config_path: Optional[Path]) -> Dict[str, Any]:
+        """Loads and validates the configuration file."""
+        if not config_path:
+            config_path = Path(__file__).parent / "asr_config.json"
+        
+        if not config_path.exists():
+            raise FileNotFoundError(f"ASR configuration file not found: {config_path}")
+        
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+        
+        # Validate version
+        version = config.get("version", "unknown")
+        if not version.startswith("4."):
+            logger.warning(f"Expected v4.x config, got version: {version}")
+        
+        logger.debug(f"Successfully loaded config version {version}")
+        return config
+    
+    def _validate_config_structure(self):
+        """Validates that all required config sections are present."""
+        required_sections = [
+            'pipeline_parameter_map',
+            'models',
+            'pipelines',
+            'common_transcriber_options',
+            'common_decoder_options'
+        ]
+        
+        for section in required_sections:
+            if section not in self.config:
+                raise ValueError(f"Missing required config section: {section}")
+        
+        # Validate pipeline_parameter_map structure
+        for pipeline_name, pipeline_map in self.config['pipeline_parameter_map'].items():
+            if 'common' not in pipeline_map:
+                raise ValueError(f"Pipeline {pipeline_name} missing 'common' in parameter map")
+            if 'engine' not in pipeline_map:
+                raise ValueError(f"Pipeline {pipeline_name} missing 'engine' in parameter map")
+    
+    @staticmethod
+    def _validate_and_convert_parameter_types(params: Dict[str, Any], backend: str) -> Dict[str, Any]:
+        """
+        Validate and convert parameter types based on the backend being used.
+        
+        Different backends (stable-ts, whisper, faster-whisper) have different
+        type requirements for the same parameters.
+        
+        Args:
+            params: Parameters dictionary to validate
+            backend: Backend name ('stable-ts', 'whisper', etc.)
+            
+        Returns:
+            Parameters dictionary with correct types
+        """
+        if not isinstance(params, dict):
+            return params
+            
+        validated_params = params.copy()
+        
+        # Backend-specific type requirements
+        if backend == 'stable-ts':
+            type_conversions = {
+                # These should be integers for stable-ts/faster-whisper (ctranslate2)
+                'beam_size': int,
+                'best_of': int,
+                'batch_size': int,
+                'max_new_tokens': int,
+                'language_detection_segments': int,
+                'ts_num': int,
+                'q_levels': int,
+                'k_size': int,
+                'no_repeat_ngram_size': int,  # FIX: ctranslate2 expects int, not float!
+                
+                # These should be floats for stable-ts
+                'patience': float,
+                'length_penalty': float,
+                'repetition_penalty': float,
+                'compression_ratio_threshold': float,
+                'logprob_threshold': float,
+                'logprob_margin': float,
+                'no_speech_threshold': float,
+                'drop_nonverbal_vocals': bool,
+                'vad_threshold': float,
+                'max_instant_words': float,
+                'avg_prob_threshold': float,
+                'nonspeech_error': float,
+                'min_word_dur': float,
+                'min_silence_dur': float,
+                'hallucination_silence_threshold': float,
+                'time_scale': float,
+                
+                # These should be strings for stable-ts
+                'task': str,
+                'language': str,
+                'gap_padding': str,
+                'prefix': str,
+                
+                # These should be booleans for stable-ts
+                'condition_on_previous_text': bool,
+                'suppress_blank': bool,
+                'without_timestamps': bool,
+                'word_timestamps': bool,
+                'fp16': bool,
+                'vad': bool,
+                'suppress_ts_tokens': bool,
+                'only_ffmpeg': bool,
+                'log_progress': bool,
+                'multilingual': bool,
+                'ignore_compatibility': bool,
+                'regroup': bool,
+                'suppress_silence': bool,
+                'suppress_word_ts': bool,
+                'suppress_attention': bool,
+                'use_word_position': bool,
+                'only_voice_freq': bool,
+                'demucs': bool,
+            }
+        else:  # whisper and other backends are more flexible
+            type_conversions = {
+                'task': str,
+                'language': str,
+                'fp16': bool,
+                'beam_size': int,
+                'best_of': int,
+                'patience': float,
+                'logprob_margin': float,
+                'drop_nonverbal_vocals': bool,
+            }
+        
+        # Special handling for suppress_tokens (common issue across backends)
+        if 'suppress_tokens' in validated_params:
+            suppress_val = validated_params['suppress_tokens']
+            
+            if backend == 'stable-ts':
+                # Faster-whisper (used by stable-ts in turbo mode) expects suppress_tokens to be iterable
+                if suppress_val == "-1" or suppress_val == -1:
+                    # Convert -1 (disable suppression) to None for faster-whisper compatibility
+                    del validated_params['suppress_tokens']  # Remove entirely - let library use defaults
+                    logger.debug(f"Backend {backend}: Removed suppress_tokens=-1 for faster-whisper compatibility")
+                elif isinstance(suppress_val, str):
+                    try:
+                        int_val = int(suppress_val)
+                        if int_val == -1:
+                            del validated_params['suppress_tokens']  # Remove -1
+                            logger.debug(f"Backend {backend}: Removed suppress_tokens='{suppress_val}' for faster-whisper compatibility")
+                        else:
+                            validated_params['suppress_tokens'] = [int_val]  # Convert to list
+                            logger.debug(f"Backend {backend}: Converted suppress_tokens to list: {[int_val]}")
+                    except ValueError:
+                        logger.warning(f"Invalid suppress_tokens value: {suppress_val}, removing parameter")
+                        del validated_params['suppress_tokens']
+                elif isinstance(suppress_val, int):
+                    if suppress_val == -1:
+                        del validated_params['suppress_tokens']  # Remove -1
+                        logger.debug(f"Backend {backend}: Removed suppress_tokens=-1 for faster-whisper compatibility")
+                    else:
+                        validated_params['suppress_tokens'] = [suppress_val]  # Convert to list
+                        logger.debug(f"Backend {backend}: Converted suppress_tokens to list: {[suppress_val]}")
+                elif not isinstance(suppress_val, list):
+                    logger.warning(f"Invalid suppress_tokens type for {backend}: {type(suppress_val)}, removing parameter")
+                    del validated_params['suppress_tokens']
+            else:
+                # Standard whisper backend - original handling
+                if suppress_val == "-1" or suppress_val == -1:
+                    validated_params['suppress_tokens'] = -1  # Keep as -1 for standard whisper
+                elif isinstance(suppress_val, str):
+                    try:
+                        validated_params['suppress_tokens'] = int(suppress_val)
+                    except ValueError:
+                        logger.warning(f"Invalid suppress_tokens value: {suppress_val}, removing parameter")
+                        del validated_params['suppress_tokens']
+                elif not isinstance(suppress_val, (int, list)):
+                    logger.warning(f"Invalid suppress_tokens type: {type(suppress_val)}, removing parameter")
+                    del validated_params['suppress_tokens']
+        
+        # Apply type conversions
+        for param_name, target_type in type_conversions.items():
+            if param_name in validated_params:
+                current_value = validated_params[param_name]
+                
+                # Skip if already correct type or None
+                if current_value is None or isinstance(current_value, target_type):
+                    continue
+                
+                try:
+                    # Convert to target type
+                    if target_type == bool:
+                        # Special handling for boolean conversion
+                        if isinstance(current_value, str):
+                            validated_params[param_name] = current_value.lower() in ('true', '1', 'yes', 'on')
+                        else:
+                            validated_params[param_name] = bool(current_value)
+                    else:
+                        validated_params[param_name] = target_type(current_value)
+                        
+                    logger.debug(f"Backend {backend}: Converted {param_name} from {type(current_value)} to {target_type}")
+                    
+                except (ValueError, TypeError) as e:
+                    logger.warning(f"Backend {backend}: Failed to convert {param_name}={current_value} to {target_type}: {e}")
+                    logger.warning(f"Removing invalid parameter: {param_name}")
+                    del validated_params[param_name]
+        
+        return validated_params
+
+    @staticmethod
+    def _remove_none_values(data: Dict[str, Any], preserve_none_keys: Optional[List[str]] = None) -> Dict[str, Any]:
+        """
+        Recursively remove None values from a dictionary.
+        This prevents None values from being passed to libraries that don't handle them properly.
+        
+        In JSON configs, 'null' becomes 'None' in Python. Most ML libraries expect parameters
+        to either have valid values or be omitted entirely, not passed as None.
+        
+        Args:
+            data: Dictionary that may contain None values
+            preserve_none_keys: Optional list of keys where None values should be preserved
+            
+        Returns:
+            Dictionary with None values removed (except for preserved keys)
+        """
+        if not isinstance(data, dict):
+            return data
+            
+        preserve_none_keys = preserve_none_keys or []
+        cleaned = {}
+        
+        for key, value in data.items():
+            if value is None:
+                # Only preserve None if explicitly specified
+                if key in preserve_none_keys:
+                    cleaned[key] = value
+                    logger.debug(f"Preserved None value for parameter: {key}")
+                else:
+                    logger.debug(f"Removed None value for parameter: {key}")
+                continue  # Skip None values (unless preserved)
+            elif isinstance(value, dict):
+                # Recursively clean nested dictionaries
+                cleaned_nested = TranscriptionTuner._remove_none_values(value, preserve_none_keys)
+                if cleaned_nested:  # Only add if not empty after cleaning
+                    cleaned[key] = cleaned_nested
+            elif isinstance(value, list):
+                # Clean lists, removing None values (but preserve empty lists)
+                cleaned_list = [v for v in value if v is not None]
+                cleaned[key] = cleaned_list  # Keep even if empty - empty list != omitted parameter
+            else:
+                cleaned[key] = value
+        
+        return cleaned
+        """
+        Recursively remove None values from a dictionary.
+        This prevents None values from being passed to libraries that don't handle them properly.
+        
+        In JSON configs, 'null' becomes 'None' in Python. Most ML libraries expect parameters
+        to either have valid values or be omitted entirely, not passed as None.
+        
+        Args:
+            data: Dictionary that may contain None values
+            preserve_none_keys: Optional list of keys where None values should be preserved
+            
+        Returns:
+            Dictionary with None values removed (except for preserved keys)
+        """
+        if not isinstance(data, dict):
+            return data
+            
+        preserve_none_keys = preserve_none_keys or []
+        cleaned = {}
+        
+        for key, value in data.items():
+            if value is None:
+                # Only preserve None if explicitly specified
+                if key in preserve_none_keys:
+                    cleaned[key] = value
+                    logger.debug(f"Preserved None value for parameter: {key}")
+                else:
+                    logger.debug(f"Removed None value for parameter: {key}")
+                continue  # Skip None values (unless preserved)
+            elif isinstance(value, dict):
+                # Recursively clean nested dictionaries
+                cleaned_nested = TranscriptionTuner._remove_none_values(value, preserve_none_keys)
+                if cleaned_nested:  # Only add if not empty after cleaning
+                    cleaned[key] = cleaned_nested
+            elif isinstance(value, list):
+                # Clean lists, removing None values (but preserve empty lists)
+                cleaned_list = [v for v in value if v is not None]
+                cleaned[key] = cleaned_list  # Keep even if empty - empty list != omitted parameter
+            else:
+                cleaned[key] = value
+        
+        return cleaned
+    
+    def resolve_params(self, pipeline_name: str, sensitivity: str, task: str, **kwargs) -> Dict[str, Any]:
+        """
+        Resolves all necessary configurations for a given run.
+        
+        Args:
+            pipeline_name: The name of the pipeline ('faster', 'fast', 'balanced')
+            sensitivity: The sensitivity profile ('conservative', 'balanced', 'aggressive')
+            task: The ASR task ('transcribe' or 'translate')
+            
+        Returns:
+            A structured dictionary matching pipeline expectations.
+        """
+        # Validate inputs
+        if pipeline_name not in self.config['pipeline_parameter_map']:
+            raise ValueError(f"Unknown pipeline specified: '{pipeline_name}'")
+        
+        if pipeline_name not in self.config['pipelines']:
+            raise ValueError(f"Pipeline definition not found: '{pipeline_name}'")
+        
+        # Get pipeline configuration
+        pipeline_cfg = self.config['pipelines'][pipeline_name]
+        pipeline_map = self.config['pipeline_parameter_map'][pipeline_name]
+        workflow = deepcopy(pipeline_cfg['workflow'])
+        
+        # Initialize parameter containers
+        decoder_params = {}
+        provider_params = {}
+        vad_params = {}
+        stable_ts_params = {}
+        
+        # 1. Process common parameters
+        common_sections = pipeline_map.get('common', [])
+        if isinstance(common_sections, str):
+            common_sections = [common_sections]
+        
+        for section_name in common_sections:
+            if section_name not in self.config:
+                logger.warning(f"Common section '{section_name}' not found in config")
+                continue
+            
+            if sensitivity not in self.config[section_name]:
+                raise ValueError(f"Sensitivity '{sensitivity}' not found in {section_name}")
+            
+            section_data = deepcopy(self.config[section_name][sensitivity])
+            
+            if section_name == 'common_decoder_options':
+                # Decoder params go to their own section
+                decoder_params = section_data
+            else:
+                # Everything else merges into provider params
+                provider_params.update(section_data)
+        
+        # 2. Process engine-specific parameters
+        engine_sections = pipeline_map.get('engine', [])
+        if isinstance(engine_sections, str):
+            engine_sections = [engine_sections]
+        
+        for section_name in engine_sections:
+            if section_name not in self.config:
+                logger.warning(f"Engine section '{section_name}' not found in config")
+                continue
+            
+            if sensitivity not in self.config[section_name]:
+                logger.warning(f"Sensitivity '{sensitivity}' not found in {section_name}")
+                continue
+            
+            section_data = deepcopy(self.config[section_name][sensitivity])
+            
+            # Stable-ts engine options could be kept separate for clarity
+            if 'stable_ts' in section_name:
+                stable_ts_params.update(section_data)
+            
+            # All engine params go to provider
+            provider_params.update(section_data)
+        
+        # 3. Process VAD parameters based on handling type
+        if pipeline_map.get('vad'):
+            vad_section = pipeline_map['vad']
+            vad_handling = pipeline_map.get('vad_handling', 'packed')
+
+            if vad_section in self.config and sensitivity in self.config[vad_section]:
+                vad_data = deepcopy(self.config[vad_section][sensitivity])
+
+                # NEW: Resolve VAD engine repo URL from workflow
+                vad_engine_id = workflow.get('vad')  # e.g., "silero-v3.1"
+                if vad_engine_id and vad_engine_id != 'none':
+                    if 'vad_engines' in self.config and vad_engine_id in self.config['vad_engines']:
+                        vad_engine_config = self.config['vad_engines'][vad_engine_id]
+                        vad_data['vad_repo'] = vad_engine_config['repo']
+                        vad_data['vad_provider'] = vad_engine_config['provider']
+                        logger.debug(f"Resolved VAD engine '{vad_engine_id}' to repo: {vad_engine_config['repo']}")
+                    else:
+                        logger.warning(f"VAD engine '{vad_engine_id}' not found in vad_engines config")
+
+                if vad_handling == 'packed':
+                    # Pack VAD params into provider (for StableTSASR)
+                    provider_params.update(vad_data)
+                    logger.debug(f"Packed VAD params from {vad_section} into provider params")
+                else:  # 'separate'
+                    # Keep VAD params separate (for WhisperProASR)
+                    vad_params = vad_data
+                    logger.debug(f"Kept VAD params from {vad_section} separate")
+        
+        # 4. Handle model selection (with task-based override)
+        model_overrides = pipeline_cfg.get('model_overrides', {})
+        model_id = model_overrides.get(task, workflow['model'])
+        
+        if model_id not in self.config['models']:
+            raise ValueError(f"Model not found: {model_id}")
+        
+        model_cfg = deepcopy(self.config['models'][model_id])
+        
+        # 5. Override task in decoder params
+        if decoder_params:
+            decoder_params['task'] = task
+        
+        # 6. Extract features from workflow
+        features = {}
+        if 'features' in workflow:
+            for feature_name, feature_config in workflow['features'].items():
+                if feature_config and feature_config != 'none':
+                    # Look up feature configuration
+                    if feature_name in self.config.get('feature_configs', {}):
+                        # Special handling for scene_detection method selection
+                        if feature_name == 'scene_detection':
+                            # Check if method is specified in kwargs
+                            method = kwargs.get('scene_detection_method', None)
+                            if method is None:
+                                method = self.config['feature_configs']['scene_detection'].get('default_method', 'auditok')
+
+                            # Load method-specific config
+                            if method in self.config['feature_configs']['scene_detection']:
+                                features[feature_name] = deepcopy(
+                                    self.config['feature_configs']['scene_detection'][method]
+                                )
+                                features[feature_name]['method'] = method  # Pass method to detector
+                                logger.debug(f"Loaded scene_detection config for method: {method}")
+                            else:
+                                logger.warning(f"Unknown scene detection method: {method}, falling back to auditok")
+                                features[feature_name] = deepcopy(
+                                    self.config['feature_configs']['scene_detection']['auditok']
+                                )
+                                features[feature_name]['method'] = 'auditok'
+                        else:
+                            # Normal feature loading
+                            config_key = feature_config if isinstance(feature_config, str) else 'default'
+                            if config_key in self.config['feature_configs'][feature_name]:
+                                features[feature_name] = deepcopy(
+                                    self.config['feature_configs'][feature_name][config_key]
+                                )
+        
+        # 7. CLEAN ALL PARAMETER DICTIONARIES - Remove None values before returning
+        # This prevents None values from being passed to libraries that don't handle them properly
+        decoder_params = self._remove_none_values(decoder_params)
+        provider_params = self._remove_none_values(provider_params)
+        vad_params = self._remove_none_values(vad_params)
+        stable_ts_params = self._remove_none_values(stable_ts_params)
+        features = self._remove_none_values(features)
+        
+        # 8. APPLY BACKEND-SPECIFIC TYPE VALIDATION
+        # Determine backend from workflow
+        backend = workflow.get('backend', 'whisper')  # default to 'whisper'
+        
+        # Apply type validation based on backend
+        if backend == 'stable-ts':
+            decoder_params = self._validate_and_convert_parameter_types(decoder_params, 'stable-ts')
+            provider_params = self._validate_and_convert_parameter_types(provider_params, 'stable-ts')
+            logger.debug(f"Applied stable-ts type validation for {pipeline_name}/{sensitivity}")
+        else:
+            decoder_params = self._validate_and_convert_parameter_types(decoder_params, 'whisper')
+            provider_params = self._validate_and_convert_parameter_types(provider_params, 'whisper')
+            logger.debug(f"Applied whisper type validation for {pipeline_name}/{sensitivity}")
+        
+        logger.debug(f"Cleaned parameters and applied type validation for {pipeline_name}/{sensitivity}")
+        
+        # 9. Build the return structure expected by pipelines
+        return {
+            'pipeline_name': pipeline_name,
+            'sensitivity_name': sensitivity,
+            'workflow': workflow,
+            'model': model_cfg,
+            'params': {
+                'decoder': decoder_params,
+                'provider': provider_params,
+                'vad': vad_params,
+                # Optionally include stable_ts separately if needed
+                # 'stable_ts': stable_ts_params
+            },
+            'features': features,
+            'task': task,
+            'language': decoder_params.get('language', 'ja')
+        }
+    
+    def get_ui_preferences(self) -> Dict[str, Any]:
+        """Returns UI preferences from config."""
+        return self.config.get('ui_preferences', {})
+    
+    def get_defaults(self) -> Dict[str, Any]:
+        """Returns default settings from config."""
+        return self.config.get('defaults', {})
+    
+    def list_pipelines(self) -> List[str]:
+        """Returns list of available pipelines."""
+        return list(self.config.get('pipeline_parameter_map', {}).keys())
+    
+    def list_sensitivity_profiles(self) -> List[str]:
+        """Returns list of available sensitivity profiles."""
+        # Get from any common section since all should have same profiles
+        if 'common_decoder_options' in self.config:
+            return list(self.config['common_decoder_options'].keys())
+        return ['conservative', 'balanced', 'aggressive']
+    
+    def get_pipeline_info(self, pipeline_name: str) -> Dict[str, Any]:
+        """Returns information about a specific pipeline."""
+        if pipeline_name not in self.config.get('pipelines', {}):
+            raise ValueError(f"Pipeline not found: {pipeline_name}")
+        return deepcopy(self.config['pipelines'][pipeline_name])
+    
+    def validate_configuration(self) -> bool:
+        """
+        Validates the entire configuration for consistency.
+        Returns True if valid, raises exceptions with details if not.
+        """
+        pipelines = self.list_pipelines()
+        sensitivities = self.list_sensitivity_profiles()
+        
+        for pipeline in pipelines:
+            for sensitivity in sensitivities:
+                for task in ['transcribe', 'translate']:
+                    try:
+                        result = self.resolve_params(pipeline, sensitivity, task)
+                        # Verify required structure
+                        assert 'params' in result
+                        assert 'decoder' in result['params']
+                        assert 'provider' in result['params']
+                        assert 'vad' in result['params']
+                    except Exception as e:
+                        raise ValueError(
+                            f"Configuration validation failed for "
+                            f"{pipeline}/{sensitivity}/{task}: {e}"
+                        )
+        
+        logger.info("Configuration validation successful")
+        return True

--- a/whisperjav/ensemble/pass_worker.py
+++ b/whisperjav/ensemble/pass_worker.py
@@ -24,6 +24,7 @@ from whisperjav.pipelines.kotoba_faster_whisper_pipeline import (
 )
 from whisperjav.pipelines.transformers_pipeline import TransformersPipeline
 from whisperjav.pipelines.qwen_pipeline import QwenPipeline
+from whisperjav.pipelines.sensevoice_pipeline import SenseVoicePipeline
 from whisperjav.utils.logger import logger, setup_logger
 from whisperjav.utils.parameter_tracer import create_tracer, NullTracer
 
@@ -37,6 +38,7 @@ PIPELINE_CLASSES = {
     "kotoba-faster-whisper": KotobaFasterWhisperPipeline,
     "transformers": TransformersPipeline,
     "qwen": QwenPipeline,  # Dedicated Qwen3-ASR pipeline (ADR-004)
+    "sensevoice": SenseVoicePipeline,  # FunASR SenseVoice (issue #350)
 }
 
 DEFAULT_HF_PARAMS = {
@@ -366,6 +368,74 @@ def prepare_transformers_params(pass_config: Dict[str, Any]) -> Dict[str, Any]:
     for key, hf_key in override_mapping.items():
         if key in overrides:
             params[hf_key] = overrides[key]
+
+    return params
+
+
+# Default SenseVoice parameters (issue #350)
+DEFAULT_SV_PARAMS = {
+    "sv_model_id": "iic/SenseVoiceSmall",
+    "sv_device": "auto",
+    "sv_language": "ja",
+    "sv_use_itn": True,
+    "sv_vad_model": "fsmn-vad",
+    "sv_scene": "auditok",
+    "sv_task": "transcribe",
+    # Post-processing (relaxed for SenseVoice — Whisper-tuned filters over-remove
+    # its per-scene short lines). (#350)
+    "sv_remove_hallucinations": False,
+    "sv_remove_repetitions": True,
+    "sv_remove_cps_outliers": False,
+    "sv_diarize": False,
+}
+
+
+def prepare_sensevoice_params(pass_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return sv_* parameters for the SenseVoice pipeline with overrides applied."""
+    params = DEFAULT_SV_PARAMS.copy()
+
+    # The customize modal sends its values via the generic "params" dict; the
+    # CLI/legacy paths may use "sensevoice_params"/"sv_params". Merge all.
+    sv_params = {
+        **(pass_config.get("params") or {}),
+        **(pass_config.get("sensevoice_params") or {}),
+        **(pass_config.get("sv_params") or {}),
+    }
+    mapping = {
+        "model_id": "sv_model_id",
+        "device": "sv_device",
+        "language": "sv_language",
+        "use_itn": "sv_use_itn",
+        "ban_emo_unk": "sv_ban_emo_unk",
+        "vad_model": "sv_vad_model",
+        "merge_vad": "sv_merge_vad",
+        "merge_length_s": "sv_merge_length_s",
+        "vad_max_segment_ms": "sv_vad_max_segment_ms",
+        "batch_size_s": "sv_batch_size_s",
+        "bsrf_overlap": "sv_bsrf_overlap",
+        "scene": "sv_scene",
+        "task": "sv_task",
+        "remove_hallucinations": "sv_remove_hallucinations",
+        "remove_repetitions": "sv_remove_repetitions",
+        "remove_cps_outliers": "sv_remove_cps_outliers",
+        "diarize": "sv_diarize",
+        "spk_num": "sv_spk_num",
+    }
+    for key, value in sv_params.items():
+        if key in mapping:
+            params[mapping[key]] = value
+        elif key.startswith("sv_"):
+            params[key] = value
+
+    overrides = pass_config.get("overrides") or {}
+    override_mapping = {
+        "language": "sv_language",
+        "device": "sv_device",
+        "task": "sv_task",
+    }
+    for key, sv_key in override_mapping.items():
+        if key in overrides:
+            params[sv_key] = overrides[key]
 
     return params
 
@@ -1296,6 +1366,75 @@ def _build_pipeline(
             logger.error(
                 "[Worker %s] Pass %s: FAILED to create QwenPipeline - %s: %s",
                 os.getpid(), pass_number, type(e).__name__, e
+            )
+            raise
+
+    # SenseVoice pipeline (FunASR, issue #350) — uses sv_* kwargs, not legacy config
+    if pipeline_name == "sensevoice":
+        sv_defaults = prepare_sensevoice_params(pass_config)
+        sv_defaults["sv_task"] = asr_task
+        # Apply GUI-specified overrides. The ensemble Model dropdown defaults to
+        # Whisper model ids (large-v2/turbo) for "legacy" pipelines; only honour
+        # a model override that is actually a FunASR/SenseVoice model id, so a
+        # stale Whisper id doesn't get forwarded to SenseVoice.
+        _model = pass_config.get("model")
+        if _model and ("sensevoice" in _model.lower() or "/" in _model):
+            sv_defaults["sv_model_id"] = _model
+            logger.debug("Pass %s: Override sv_model_id = %s", pass_number, _model)
+        elif _model:
+            logger.debug(
+                "Pass %s: Ignoring non-SenseVoice model override '%s'; using %s",
+                pass_number, _model, sv_defaults["sv_model_id"],
+            )
+        if pass_config.get("scene_detector") and pass_config["scene_detector"] != "none":
+            sv_defaults["sv_scene"] = pass_config["scene_detector"]
+            logger.debug("Pass %s: Override sv_scene = %s", pass_number, pass_config["scene_detector"])
+        elif pass_config.get("scene_detector") == "none":
+            sv_defaults["sv_scene"] = "none"
+        if pass_config.get("language"):
+            sv_defaults["sv_language"] = pass_config["language"]
+            logger.debug("Pass %s: Override sv_language = %s", pass_number, pass_config["language"])
+        # The Speech Segmenter dropdown is repurposed for SenseVoice to toggle
+        # its internal FunASR VAD (fsmn-vad). "none" disables it; anything else
+        # (or unset) keeps fsmn-vad on.
+        _seg = pass_config.get("speech_segmenter")
+        if _seg == "none":
+            sv_defaults["sv_vad_model"] = None
+            logger.debug("Pass %s: SenseVoice internal VAD disabled (segmenter=none)", pass_number)
+        elif _seg:
+            sv_defaults["sv_vad_model"] = "fsmn-vad"
+        # Speech enhancer (e.g. bs-roformer:vocals) — cleans audio before ASR.
+        if pass_config.get("speech_enhancer"):
+            _enh_backend, _enh_model = _parse_speech_enhancer(pass_config["speech_enhancer"])
+            sv_defaults["sv_speech_enhancer"] = _enh_backend
+            if _enh_model:
+                sv_defaults["sv_speech_enhancer_model"] = _enh_model
+            logger.debug("Pass %s: SenseVoice enhancer = %s (model=%s)", pass_number, _enh_backend, _enh_model)
+        logger.debug(
+            "[Worker %s] Pass %s: Creating SenseVoicePipeline with sv_model_id=%s, sv_language=%s, sv_scene=%s, sv_vad_model=%s",
+            os.getpid(), pass_number,
+            sv_defaults.get("sv_model_id"), sv_defaults.get("sv_language"),
+            sv_defaults.get("sv_scene"), sv_defaults.get("sv_vad_model"),
+        )
+        try:
+            pipeline = SenseVoicePipeline(
+                output_dir=output_dir,
+                temp_dir=str(pass_temp_dir),
+                keep_temp_files=keep_temp_files,
+                progress_display=None,
+                subs_language=subs_language,
+                parameter_tracer=tracer,
+                **sv_defaults,
+            )
+            logger.debug(
+                "[Worker %s] Pass %s: SenseVoicePipeline created successfully",
+                os.getpid(), pass_number,
+            )
+            return pipeline
+        except Exception as e:
+            logger.error(
+                "[Worker %s] Pass %s: FAILED to create SenseVoicePipeline - %s: %s",
+                os.getpid(), pass_number, type(e).__name__, e,
             )
             raise
 

--- a/whisperjav/main.py
+++ b/whisperjav/main.py
@@ -1353,6 +1353,9 @@ def process_files_sync(media_files: List[Dict], args: argparse.Namespace, resolv
                 logger.error(f"Invalid JSON in --sv-params: {e}")
                 _sv_params = {}
             _modal_to_kw = {
+                "model_id": "sv_model_id",
+                "device": "sv_device",
+                "scene": "sv_scene",
                 "use_itn": "sv_use_itn",
                 "ban_emo_unk": "sv_ban_emo_unk",
                 "merge_vad": "sv_merge_vad",

--- a/whisperjav/main.py
+++ b/whisperjav/main.py
@@ -162,7 +162,7 @@ def parse_arguments():
     # Core arguments
     parser.add_argument("input", nargs="*", help="Input media file(s), directory, or wildcard pattern.")
     # Note: kotoba-faster-whisper temporarily hidden from user selection (implementation preserved)
-    parser.add_argument("--mode", choices=["fidelity", "balanced", "fast", "faster", "transformers", "qwen"], default="balanced",
+    parser.add_argument("--mode", choices=["fidelity", "balanced", "fast", "faster", "transformers", "qwen", "sensevoice"], default="balanced",
                        help="Processing mode (default: balanced)")
     parser.add_argument("--model", default=None,
                        help="Override the default Whisper model (e.g., large-v2, turbo, large). Overrides config default.")
@@ -192,7 +192,7 @@ def parse_arguments():
                                help="Enable two-pass ensemble mode")
     # Note: kotoba-faster-whisper temporarily hidden from user selection (implementation preserved)
     twopass_group.add_argument("--pass1-pipeline", default="balanced",
-                               choices=["balanced", "fast", "faster", "fidelity", "transformers", "qwen"],
+                               choices=["balanced", "fast", "faster", "fidelity", "transformers", "qwen", "sensevoice"],
                                help="Pipeline for pass 1 (default: balanced)")
     twopass_group.add_argument("--pass1-sensitivity", default="balanced",
                                choices=["conservative", "balanced", "aggressive"],
@@ -222,7 +222,7 @@ def parse_arguments():
                                help="Speech padding in ms for pass 1")
     # Note: kotoba-faster-whisper temporarily hidden from user selection (implementation preserved)
     twopass_group.add_argument("--pass2-pipeline", default=None,
-                               choices=["balanced", "fast", "faster", "fidelity", "transformers", "qwen", "xxl"],
+                               choices=["balanced", "fast", "faster", "fidelity", "transformers", "qwen", "sensevoice", "xxl"],
                                help="Pipeline for pass 2 (enables pass 2). 'xxl' = BYOP XXL Faster Whisper (requires --xxl-exe)")
     twopass_group.add_argument("--pass2-sensitivity", default="balanced",
                                choices=["conservative", "balanced", "aggressive"],
@@ -370,6 +370,20 @@ def parse_arguments():
                              choices=["true", "false"],
                              metavar="BOOL",
                              help="Enable/disable conditioning on previous text (default: mode-dependent)")
+    tuning_group.add_argument("--batched-pipeline",
+                             type=str, default=None,
+                             choices=["true", "false"],
+                             metavar="BOOL",
+                             help=(
+                                 "Use faster-whisper BatchedInferencePipeline to batch the "
+                                 "encoder across VAD groups in the balanced pipeline "
+                                 "(5-20x transcription speedup, on by default). "
+                                 "Set to false to use the legacy sequential per-segment path."
+                             ))
+    tuning_group.add_argument("--batch-size",
+                             type=int, default=None,
+                             metavar="INT",
+                             help="Number of VAD groups decoded in parallel when --batched-pipeline is on (default: 8)")
 
     # Async processing
     async_group = parser.add_argument_group("Processing Options")
@@ -502,6 +516,74 @@ def parse_arguments():
     hf_group.add_argument("--hf-dtype", type=str, default="auto",
                          choices=["auto", "float16", "bfloat16", "float32"],
                          help="Data type (default: auto)")
+
+    # ── SenseVoice Mode (--mode sensevoice) ─────────────────────────────
+    sv_group = parser.add_argument_group("SenseVoice Mode Options (--mode sensevoice)")
+    sv_group.add_argument("--sv-model-id", type=str, default="iic/SenseVoiceSmall",
+                         help="FunASR/ModelScope model id (default: iic/SenseVoiceSmall)")
+    sv_group.add_argument("--sv-language", type=str, default="ja",
+                         choices=["ja", "en", "zh", "yue", "ko", "auto"],
+                         help="Source language (default: ja). 'auto' = detect.")
+    sv_group.add_argument("--sv-scene", type=str, default="auditok",
+                         choices=["none", "auditok", "silero", "semantic"],
+                         help="Scene detection method providing subtitle granularity (default: auditok)")
+    sv_group.add_argument("--sv-device", type=str, default="auto",
+                         choices=["auto", "cuda", "cpu"],
+                         help="Device to use (default: auto)")
+    sv_group.add_argument("--sv-no-itn", action="store_true",
+                         help="Disable inverse text normalization (punctuation/number formatting)")
+    sv_group.add_argument("--sv-no-vad", action="store_true",
+                         help="Disable SenseVoice's internal FunASR VAD chunking")
+    sv_group.add_argument("--sv-speech-enhancer", type=str, default="none",
+                         metavar="BACKEND",
+                         help=(
+                             "Speech enhancer applied BEFORE SenseVoice transcribes "
+                             "(none/clearvoice/bs-roformer/zipenhancer/ffmpeg-dsp). "
+                             "bs-roformer isolates vocals from music/background — helps "
+                             "noisy scenes. Format: 'bs-roformer' or 'bs-roformer:vocals'. Default: none"
+                         ))
+    sv_group.add_argument("--sv-speech-enhancer-model", type=str, default=None,
+                         metavar="MODEL",
+                         help="Speech enhancer model variant (e.g. 'vocals' for bs-roformer)")
+    sv_group.add_argument("--sv-bsrf-overlap", type=int, default=None,
+                         metavar="INT",
+                         help=(
+                             "BS-RoFormer chunk overlap (speed/quality knob). Default 2 "
+                             "(per model config). Lower (e.g. 1) ~halves separation time at "
+                             "a small quality cost; higher is slower/cleaner. Only applies "
+                             "when --sv-speech-enhancer is bs-roformer."
+                         ))
+    # Post-processing controls. The shared sanitizer is Whisper-tuned and over-
+    # removes SenseVoice lines; these default OFF (relaxed) for SenseVoice and
+    # can be turned back on. (#350)
+    sv_group.add_argument("--sv-remove-hallucinations", action="store_true",
+                         help=("Apply the Whisper hallucination blacklist (exact/regex/fuzzy) "
+                               "to SenseVoice output. OFF by default — SenseVoice's short "
+                               "utterances collide with Whisper-tuned phrases and get dropped."))
+    sv_group.add_argument("--sv-no-remove-repetitions", action="store_true",
+                         help="Disable repetition cleaning for SenseVoice (on by default).")
+    sv_group.add_argument("--sv-remove-cps-outliers", action="store_true",
+                         help=("Apply the abnormal-CPS (too-fast/too-slow) line drop to "
+                               "SenseVoice. OFF by default — SenseVoice spans a whole "
+                               "utterance across the scene, so genuine short lines look "
+                               "'too slow' and would be removed."))
+    sv_group.add_argument("--sv-diarize", action="store_true",
+                         help=("Enable speaker diarization (FunASR cam++). Adds "
+                               "per-sentence [spkN] labels. Runs SenseVoice on the "
+                               "full audio (scene detection is auto-disabled) so "
+                               "speaker ids stay consistent; downloads the cam++ "
+                               "model (~ModelScope) on first use."))
+    sv_group.add_argument("--sv-spk-num", type=int, default=None, metavar="N",
+                         help=("Force a fixed speaker count for diarization "
+                               "(0/unset = cam++ auto-estimate, which often "
+                               "collapses to 1 on breathy/monologue audio; set 2+ "
+                               "when you know the scene's speaker count)."))
+    sv_group.add_argument("--sv-params", default=None, metavar="JSON",
+                         help=("JSON dict of SenseVoice customize-modal params "
+                               "(use_itn, ban_emo_unk, merge_vad, merge_length_s, "
+                               "vad_max_segment_ms, batch_size_s, diarize, "
+                               "bsrf_overlap). Used by the GUI single-pass path; "
+                               "merges over the individual --sv-* flags."))
 
     # ── Qwen3-ASR: Model ────────────────────────────────────────────────
     qwen_model_group = parser.add_argument_group("Qwen3-ASR: Model")
@@ -1225,6 +1307,71 @@ def process_files_sync(media_files: List[Dict], args: argparse.Namespace, resolv
 
         pipeline = QwenPipeline(**qwen_kwargs)
         effective_mode = args.mode
+    elif args.mode == "sensevoice":
+        # SenseVoice (FunASR) pipeline (issue #350)
+        from whisperjav.pipelines.sensevoice_pipeline import SenseVoicePipeline
+        initial_output_dir = str(Path(media_files[0]['path']).parent) if output_to_source else args.output_dir
+
+        sv_kwargs = dict(
+            output_dir=initial_output_dir,
+            temp_dir=args.temp_dir,
+            keep_temp_files=args.keep_temp,
+            save_metadata_json=getattr(args, 'debug', False),
+            progress_display=progress,
+            sv_model_id=getattr(args, 'sv_model_id', 'iic/SenseVoiceSmall'),
+            sv_device=getattr(args, 'sv_device', 'auto'),
+            sv_language=getattr(args, 'sv_language', 'ja'),
+            sv_use_itn=not getattr(args, 'sv_no_itn', False),
+            sv_vad_model=None if getattr(args, 'sv_no_vad', False) else 'fsmn-vad',
+            sv_scene=getattr(args, 'sv_scene', 'auditok'),
+            sv_task='translate' if args.subs_language == 'direct-to-english' else 'transcribe',
+            sv_speech_enhancer=(getattr(args, 'sv_speech_enhancer', 'none') or 'none').split(':', 1)[0],
+            sv_speech_enhancer_model=(
+                # Prefer 'backend:model' inline form; fall back to the explicit flag.
+                (getattr(args, 'sv_speech_enhancer', '') or '').split(':', 1)[1]
+                if ':' in (getattr(args, 'sv_speech_enhancer', '') or '')
+                else getattr(args, 'sv_speech_enhancer_model', None)
+            ),
+            sv_bsrf_overlap=getattr(args, 'sv_bsrf_overlap', None),
+            sv_remove_hallucinations=getattr(args, 'sv_remove_hallucinations', False),
+            sv_remove_repetitions=not getattr(args, 'sv_no_remove_repetitions', False),
+            sv_remove_cps_outliers=getattr(args, 'sv_remove_cps_outliers', False),
+            sv_diarize=getattr(args, 'sv_diarize', False),
+            sv_spk_num=getattr(args, 'sv_spk_num', None),
+            subs_language=args.subs_language,
+        )
+
+        # --sv-params: JSON dict of customize-modal params (GUI single-pass path).
+        # Maps each modal key to its sv_* constructor kwarg and overlays the
+        # individual --sv-* flags above. Mirrors the ensemble --passN-params path.
+        sv_params_raw = getattr(args, 'sv_params', None)
+        if sv_params_raw:
+            import json as _json
+            try:
+                _sv_params = _json.loads(sv_params_raw)
+            except Exception as e:
+                logger.error(f"Invalid JSON in --sv-params: {e}")
+                _sv_params = {}
+            _modal_to_kw = {
+                "use_itn": "sv_use_itn",
+                "ban_emo_unk": "sv_ban_emo_unk",
+                "merge_vad": "sv_merge_vad",
+                "merge_length_s": "sv_merge_length_s",
+                "vad_max_segment_ms": "sv_vad_max_segment_ms",
+                "batch_size_s": "sv_batch_size_s",
+                "bsrf_overlap": "sv_bsrf_overlap",
+                "diarize": "sv_diarize",
+                "spk_num": "sv_spk_num",
+                "remove_hallucinations": "sv_remove_hallucinations",
+                "remove_repetitions": "sv_remove_repetitions",
+                "remove_cps_outliers": "sv_remove_cps_outliers",
+            }
+            for _k, _v in _sv_params.items():
+                if _k in _modal_to_kw:
+                    sv_kwargs[_modal_to_kw[_k]] = _v
+
+        pipeline = SenseVoicePipeline(**sv_kwargs)
+        effective_mode = args.mode
     else:  # fidelity
         pipeline = FidelityPipeline(**pipeline_args)
         effective_mode = args.mode
@@ -1763,6 +1910,11 @@ def main():
             resolved_config = None
             logger.debug("Qwen mode: skipping legacy config resolution (uses --qwen-* args)")
 
+        elif args.mode == "sensevoice":
+            # SenseVoice mode: uses dedicated --sv-* arguments, not legacy config
+            resolved_config = None
+            logger.debug("SenseVoice mode: skipping legacy config resolution (uses --sv-* args)")
+
         else:
             # Legacy mode: use pipeline resolver
             resolved_config = resolve_legacy_pipeline(
@@ -1942,6 +2094,24 @@ def main():
                 resolved_config["params"]["decoder"] = {}
             resolved_config["params"]["decoder"]["condition_on_previous_text"] = condition_bool
             logger.info(f"Condition on previous text set via CLI: {condition_bool}")
+
+        # Batched transcription pipeline (issue #357) — balanced pipeline only.
+        # Routed into provider params, where FasterWhisperProASR reads it.
+        batched_pipeline = getattr(args, 'batched_pipeline', None)
+        if batched_pipeline is not None:
+            batched_bool = batched_pipeline.lower() == "true"
+            if "provider" not in resolved_config["params"]:
+                resolved_config["params"]["provider"] = {}
+            resolved_config["params"]["provider"]["use_batched_pipeline"] = batched_bool
+            logger.info(f"Batched inference pipeline set via CLI: {batched_bool}")
+
+        batch_size = getattr(args, 'batch_size', None)
+        if batch_size is not None:
+            batch_size = max(1, batch_size)
+            if "provider" not in resolved_config["params"]:
+                resolved_config["params"]["provider"] = {}
+            resolved_config["params"]["provider"]["batch_size"] = batch_size
+            logger.info(f"Batched pipeline batch size set via CLI: {batch_size}")
 
     # Handle --dump-params: dump resolved config to JSON and exit
     if args.dump_params:

--- a/whisperjav/modules/faster_whisper_pro_asr.py
+++ b/whisperjav/modules/faster_whisper_pro_asr.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Union, Optional, Any
 import gc
 import torch
-from faster_whisper import WhisperModel
+from faster_whisper import WhisperModel, BatchedInferencePipeline
 import soundfile as sf
 import numpy as np
 import srt
@@ -165,6 +165,9 @@ class FasterWhisperProASR:
         self.whisper_params.pop("logprob_margin", None)
         self.whisper_params.pop("drop_nonverbal_vocals", None)
         self.whisper_params.pop("post_model_filter_enabled", None)
+        # Batched-pipeline controls are consumed here, not by transcribe()
+        self.whisper_params.pop("use_batched_pipeline", None)
+        self.whisper_params.pop("batch_size", None)
 
         # Ensure task is set correctly
         self.whisper_params['task'] = task
@@ -172,6 +175,28 @@ class FasterWhisperProASR:
 
         # Store task for metadata
         self.task = task
+
+        # --- Batched transcription (issue #357) ---
+        # Use faster-whisper's BatchedInferencePipeline to batch the encoder
+        # across all VAD groups in a single call (5-20x speedup vs the sequential
+        # per-group loop). External speech segmentation, timestamp offsets, and
+        # the downstream segment filtering are all preserved: the VAD groups are
+        # passed as clip_timestamps so the pipeline batches over *our* segments
+        # rather than running its own internal VAD.
+        # Can be disabled via provider config (use_batched_pipeline: false) to
+        # fall back to the legacy sequential path.
+        _raw_batched = provider_params.get("use_batched_pipeline")
+        if _raw_batched is None:
+            self.use_batched_pipeline = True
+        else:
+            self.use_batched_pipeline = bool(_raw_batched)
+        # Max number of VAD groups decoded in parallel per forward pass.
+        try:
+            self.batch_size = int(provider_params.get("batch_size", 8))
+        except (TypeError, ValueError):
+            self.batch_size = 8
+        # Populated in _initialize_models() after the WhisperModel loads.
+        self.batched_pipeline = None
 
         # Log task for debugging translation issues
         logger.info(f"FasterWhisperProASR initialized with task='{task}'")
@@ -256,6 +281,7 @@ class FasterWhisperProASR:
                 f"(backend: ctranslate2, direct API - no stable-ts wrapper)"
             )
             logger.debug(f"Model type: {type(self.whisper_model)}")
+            self._initialize_batched_pipeline()
         except Exception as e:
             # VRAM exhaustion fallback - try int8 if float16/other fails on CUDA
             if self.device == "cuda" and self.compute_type != "int8":
@@ -288,6 +314,7 @@ class FasterWhisperProASR:
                         )
                         self.compute_type = "int8"  # Update for logging/metadata
                         logger.info("Faster-Whisper model loaded successfully with int8 fallback")
+                        self._initialize_batched_pipeline()
                         return
                     except Exception as fallback_e:
                         logger.error(f"int8 fallback also failed: {fallback_e}")
@@ -297,6 +324,31 @@ class FasterWhisperProASR:
             logger.error(f"Model name that failed: {self.model_name}")
             logger.error(f"Device: {self.device}, Compute type: {self.compute_type}")
             raise
+
+    def _initialize_batched_pipeline(self):
+        """Wrap the loaded WhisperModel in a BatchedInferencePipeline (issue #357).
+
+        Non-fatal: if construction fails for any reason, batching is disabled
+        and the ASR falls back to the sequential per-VAD-group path.
+        """
+        if not self.use_batched_pipeline:
+            logger.debug("Batched pipeline disabled via config (use_batched_pipeline=false)")
+            self.batched_pipeline = None
+            return
+        try:
+            self.batched_pipeline = BatchedInferencePipeline(model=self.whisper_model)
+            logger.info(
+                "BatchedInferencePipeline initialized (batch_size=%d) - "
+                "VAD groups will be transcribed in batches",
+                self.batch_size,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to initialize BatchedInferencePipeline (%s). "
+                "Falling back to sequential per-segment transcription.",
+                e,
+            )
+            self.batched_pipeline = None
 
     def _log_sensitivity_parameters(self):
         """Log the sensitivity-related parameters for debugging."""
@@ -543,6 +595,33 @@ class FasterWhisperProASR:
                 audio_duration,
             )
             all_segments = self._transcribe_full_audio(audio_data, sample_rate)
+        elif self.batched_pipeline is not None:
+            # Batched path (issue #357): transcribe all VAD groups in one call.
+            try:
+                logger.info(
+                    "Transcribing %d VAD groups via BatchedInferencePipeline "
+                    "(batch_size=%d)",
+                    len(vad_segments),
+                    self.batch_size,
+                )
+                all_segments = self._transcribe_vad_groups_batched(
+                    audio_data, sample_rate, vad_segments
+                )
+            except Exception as e:
+                # Any failure in the batched path: fall back to the proven
+                # sequential loop rather than failing the whole file.
+                logger.warning(
+                    "Batched transcription failed (%s: %s). Falling back to "
+                    "sequential per-group transcription.",
+                    type(e).__name__,
+                    e,
+                )
+                get_tracer().trace_error(e, context="batched_vad_groups")
+                all_segments = []
+                for i, vad_group in enumerate(vad_segments, 1):
+                    logger.debug(f"Processing segment group {i}/{len(vad_segments)}")
+                    segments = self._transcribe_vad_group(audio_data, sample_rate, vad_group)
+                    all_segments.extend(segments)
         else:
             all_segments = []
             for i, vad_group in enumerate(vad_segments, 1):
@@ -740,6 +819,216 @@ class FasterWhisperProASR:
             crash_tracer.trace_error(e, context="full_audio")
             logger.error(f"Full audio transcription failed: {type(e).__name__}: {e}")
             raise
+
+    def _filter_segment(self, seg: Dict, time_offset: float = 0.0) -> Optional[Dict]:
+        """Apply suppression + logprob/nonverbal filtering to one raw segment.
+
+        Shared by the sequential (_transcribe_vad_group) and batched
+        (_transcribe_vad_groups_batched) paths so both produce identical output.
+
+        Args:
+            seg: raw segment dict with 'start', 'end', 'text', 'avg_logprob'.
+                 'start'/'end' are relative to the audio chunk that produced it.
+            time_offset: seconds to add to start/end to make them absolute.
+
+        Returns:
+            The adjusted+kept segment dict, or None if it was filtered out.
+        """
+        text = seg["text"].strip() if isinstance(seg.get("text"), str) else seg.get("text", "").strip()
+        if not text:
+            return None
+
+        # Apply high suppression list filtering
+        if any(suppress in text for suppress in self.suppress_high):
+            logger.debug(f"Filtered segment due to suppression word: {text[:30]}...")
+            return None
+
+        # Apply logprob filtering with suppression penalties
+        avg_logprob = seg.get("avg_logprob", 0.0)
+        for suppress_word in self.suppress_low:
+            if suppress_word in text:
+                avg_logprob -= 0.15
+
+        segment_duration = max(0.0, float(seg["end"] - seg["start"]))
+        should_filter, reason, effective_threshold = self._segment_filter.should_filter(
+            avg_logprob=avg_logprob,
+            duration=segment_duration,
+            text=text,
+        )
+
+        if should_filter:
+            if reason == "logprob":
+                logger.debug(
+                    "Filtered segment with logprob %.3f (threshold %.3f): %s",
+                    avg_logprob,
+                    effective_threshold if effective_threshold is not None else -1.0,
+                    f"{text[:50]}...",
+                )
+                self._filter_statistics['logprob_filtered'] += 1
+            else:
+                logger.debug(f"Filtered nonverbal segment: {text[:50]}...")
+                self._filter_statistics['nonverbal_filtered'] += 1
+            return None
+
+        return {
+            "start": seg["start"] + time_offset,
+            "end": seg["end"] + time_offset,
+            "text": text,
+            "avg_logprob": avg_logprob,
+        }
+
+    def _transcribe_vad_groups_batched(self, audio_data: np.ndarray, sample_rate: int,
+                                       vad_segments: List[List[Dict]]) -> List[Dict]:
+        """Transcribe all VAD groups in a single batched call (issue #357).
+
+        Each VAD group is passed to BatchedInferencePipeline as a clip_timestamp,
+        so the pipeline batches the encoder across all groups instead of running
+        one sequential transcribe() per group. clip_timestamps suppresses the
+        pipeline's internal VAD, so our external speech segmentation is preserved.
+
+        Timestamps yielded by the pipeline are already absolute to the full audio
+        (the pipeline applies each clip's offset internally), so no per-group
+        offset is added here.
+
+        Returns the same filtered, absolute-timestamped segment list as the
+        sequential path. Raises on failure so the caller can fall back.
+        """
+        # Build clip_timestamps (seconds) from the VAD groups, in order.
+        clip_timestamps = []
+        for vad_group in vad_segments:
+            if not vad_group:
+                continue
+            clip_timestamps.append({
+                "start": float(vad_group[0]["start_sec"]),
+                "end": float(vad_group[-1]["end_sec"]),
+            })
+
+        if not clip_timestamps:
+            return []
+
+        # Prepare params and translate to the batched pipeline's API surface.
+        whisper_params = self._prepare_whisper_params()
+        batched_params = self._prepare_batched_params(whisper_params)
+
+        logger.debug("=" * 60)
+        logger.debug("DIAGNOSTIC: Batched VAD-group transcription")
+        logger.debug(f"  Model: {self.model_name}")
+        logger.debug(f"  VAD groups (clips): {len(clip_timestamps)}")
+        logger.debug(f"  batch_size: {self.batch_size}")
+        logger.debug(f"  Batched params keys: {list(batched_params.keys())}")
+        logger.debug("=" * 60)
+
+        self.tracer.emit_transcribe_params(
+            params=batched_params,
+            audio_info={
+                "duration_sec": len(audio_data) / sample_rate if sample_rate else 0.0,
+                "sample_rate": sample_rate,
+                "num_clips": len(clip_timestamps),
+            },
+            context="batched_vad_groups",
+        )
+
+        crash_tracer = get_tracer()
+        crash_tracer.trace_transcribe_start(
+            audio_info={
+                "shape": audio_data.shape,
+                "dtype": str(audio_data.dtype),
+                "duration_sec": len(audio_data) / sample_rate if sample_rate else 0.0,
+                "sample_rate": sample_rate,
+                "num_clips": len(clip_timestamps),
+                "context": "batched_vad_groups",
+            },
+            params=batched_params,
+        )
+
+        segments_generator, transcription_info = self.batched_pipeline.transcribe(
+            audio_data,
+            clip_timestamps=clip_timestamps,
+            batch_size=self.batch_size,
+            **batched_params,
+        )
+        crash_tracer.trace_transcribe_generator_created(transcription_info)
+
+        actual_task = batched_params.get('task', 'transcribe')
+
+        raw_segments = []
+        _full_segments_for_json = []
+        from dataclasses import asdict
+        for segment in segments_generator:
+            # Pipeline yields absolute start/end already (clip offsets applied).
+            raw_segments.append({
+                "start": segment.start,
+                "end": segment.end,
+                "text": segment.text,
+                "avg_logprob": segment.avg_logprob,
+            })
+            try:
+                _full_segments_for_json.append(asdict(segment))
+            except Exception:
+                pass
+
+        crash_tracer.trace_transcribe_complete(len(raw_segments))
+        logger.debug(f"Batched transcription produced {len(raw_segments)} raw segments")
+
+        # Capture full results for diagnostic JSON (single batched entry).
+        if hasattr(self, '_last_full_results'):
+            self._last_full_results.append({
+                "group_start_sec": clip_timestamps[0]["start"],
+                "group_end_sec": clip_timestamps[-1]["end"],
+                "batched": True,
+                "segments": _full_segments_for_json,
+            })
+
+        # Translation-output sanity check (mirrors sequential path).
+        if actual_task == 'translate' and raw_segments:
+            sample_text = ' '.join(seg['text'] for seg in raw_segments[:5])
+            japanese_char_count = sum(1 for c in sample_text if '぀' <= c <= 'ゟ' or
+                                                                 '゠' <= c <= 'ヿ' or
+                                                                 '一' <= c <= '鿿')
+            total_chars = len(sample_text.replace(' ', ''))
+            if total_chars > 0 and japanese_char_count / total_chars > 0.3:
+                logger.warning(
+                    "Translation mode was requested but batched output appears to be in Japanese "
+                    f"({japanese_char_count}/{total_chars} chars are Japanese)."
+                )
+
+        # Filtering. Timestamps are already absolute -> time_offset=0.0.
+        segments = []
+        for seg in raw_segments:
+            kept = self._filter_segment(seg, time_offset=0.0)
+            if kept is not None:
+                segments.append(kept)
+
+        return segments
+
+    def _prepare_batched_params(self, whisper_params: Dict) -> Dict:
+        """Strip params that BatchedInferencePipeline.transcribe() does not accept.
+
+        The batched pipeline ignores several decoding controls (it hardcodes
+        condition_on_previous_text=False, uses only temperature[0], runs its own
+        feature extraction, and ignores vad_* when clip_timestamps is given).
+        Passing unknown kwargs would raise TypeError, so drop anything not in the
+        batched signature.
+        """
+        # Accepted kwargs for BatchedInferencePipeline.transcribe (excluding
+        # audio, clip_timestamps and batch_size which we pass explicitly).
+        allowed = {
+            'language', 'task', 'log_progress', 'beam_size', 'best_of', 'patience',
+            'length_penalty', 'repetition_penalty', 'no_repeat_ngram_size',
+            'temperature', 'compression_ratio_threshold', 'log_prob_threshold',
+            'no_speech_threshold', 'condition_on_previous_text',
+            'prompt_reset_on_temperature', 'initial_prompt', 'prefix',
+            'suppress_blank', 'suppress_tokens', 'without_timestamps',
+            'max_initial_timestamp', 'word_timestamps', 'prepend_punctuations',
+            'append_punctuations', 'multilingual', 'max_new_tokens', 'chunk_length',
+            'hallucination_silence_threshold', 'hotwords',
+            'language_detection_threshold', 'language_detection_segments',
+        }
+        batched = {k: v for k, v in whisper_params.items() if k in allowed}
+        dropped = [k for k in whisper_params if k not in allowed]
+        if dropped:
+            logger.debug(f"Batched pipeline: dropped unsupported params: {dropped}")
+        return batched
 
     def _transcribe_vad_group(self, audio_data: np.ndarray, sample_rate: int,
                              vad_group: List[Dict]) -> List[Dict]:
@@ -980,54 +1269,13 @@ class FasterWhisperProASR:
         if not result or not result.get("segments"):
             return []
 
-        # Adjust timestamps and apply suppression (preserved from original)
+        # Adjust timestamps and apply suppression (shared with the batched path).
+        # Sequential timestamps are relative to the group -> offset by start_sec.
         segments = []
         for seg in result["segments"]:
-            text = seg["text"].strip() if isinstance(seg["text"], str) else seg.get("text", "").strip()
-            if not text:
-                continue
-
-            # Apply high suppression list filtering
-            if any(suppress in text for suppress in self.suppress_high):
-                logger.debug(f"Filtered segment due to suppression word: {text[:30]}...")
-                continue
-
-            # Apply logprob filtering with suppression penalties
-            avg_logprob = seg.get("avg_logprob", 0.0)
-
-            # Apply text-based suppression penalties
-            for suppress_word in self.suppress_low:
-                if suppress_word in text:
-                    avg_logprob -= 0.15
-
-            segment_duration = max(0.0, float(seg["end"] - seg["start"]))
-            should_filter, reason, effective_threshold = self._segment_filter.should_filter(
-                avg_logprob=avg_logprob,
-                duration=segment_duration,
-                text=text,
-            )
-
-            if should_filter:
-                if reason == "logprob":
-                    logger.debug(
-                        "Filtered segment with logprob %.3f (threshold %.3f): %s",
-                        avg_logprob,
-                        effective_threshold if effective_threshold is not None else -1.0,
-                        f"{text[:50]}...",
-                    )
-                    self._filter_statistics['logprob_filtered'] += 1
-                else:
-                    logger.debug(f"Filtered nonverbal segment: {text[:50]}...")
-                    self._filter_statistics['nonverbal_filtered'] += 1
-                continue
-
-            adjusted_seg = {
-                "start": seg["start"] + start_sec,
-                "end": seg["end"] + start_sec,
-                "text": text,
-                "avg_logprob": avg_logprob
-            }
-            segments.append(adjusted_seg)
+            kept = self._filter_segment(seg, time_offset=start_sec)
+            if kept is not None:
+                segments.append(kept)
 
         return segments
 
@@ -1081,6 +1329,15 @@ class FasterWhisperProASR:
         import gc
 
         logger.debug(f"Cleaning up {self.__class__.__name__} resources...")
+
+        # Release the batched pipeline (holds a reference to whisper_model)
+        try:
+            if getattr(self, 'batched_pipeline', None) is not None:
+                del self.batched_pipeline
+                self.batched_pipeline = None
+                logger.debug("Batched pipeline released")
+        except Exception as e:
+            logger.warning(f"Error releasing batched pipeline: {e}")
 
         # Delete Whisper model
         try:

--- a/whisperjav/modules/sensevoice_asr.py
+++ b/whisperjav/modules/sensevoice_asr.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+SenseVoice ASR Module for WhisperJAV (issue #350).
+
+Wraps the FunASR ``AutoModel`` running iic/SenseVoiceSmall — a fast,
+non-autoregressive multilingual ASR model (~234M params, ~1GB VRAM) with
+strong Japanese support and built-in audio-event/emotion tagging.
+
+SenseVoice is NOT a Whisper-style model: a single ``generate()`` call returns
+one (or a few VAD-merged) utterance(s) of text with rich special tokens
+(``<|ja|><|HAPPY|><|Speech|>...``) rather than per-segment timestamps. We strip
+those tokens via FunASR's ``rich_transcription_postprocess`` and return a flat
+``List[{text, start, end}]`` — the same contract as TransformersASR — so the
+pipeline's scene-detection + SRT-stitching machinery provides timing.
+
+funasr is an OPTIONAL heavy dependency. It is imported lazily inside
+``load_model`` so importing this module (and running other WhisperJAV modes)
+never requires it. If it is missing, a clear ``pip install funasr`` message is
+raised only when SenseVoice is actually used.
+
+Reference: https://github.com/FunAudioLLM/SenseVoice
+"""
+
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Any
+import contextlib
+import logging
+import time
+
+from whisperjav.utils.logger import logger
+
+
+# Benign funasr root-logger lines emitted during vad_segment-mode diarization
+# (no punc_model) even when the run succeeds. Matched as substrings.
+_BENIGN_FUNASR_DIARIZE_MSGS = (
+    "Missing punc_model, which is required by spk_model",
+    "No timestamp found in ASR result. Speaker diarization relies on timestamps",
+)
+
+
+class _DropMessagesFilter(logging.Filter):
+    """logging.Filter that drops records whose message contains any needle."""
+
+    def __init__(self, needles):
+        super().__init__()
+        self._needles = tuple(needles)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return True
+        return not any(n in msg for n in self._needles)
+
+
+@contextlib.contextmanager
+def _suppress_root_log_messages(needles):
+    """Temporarily filter specific benign messages off the ROOT logger.
+
+    funasr logs some diarization lines via bare ``logging.error(...)`` (root
+    logger), so per-logger level tweaks can't silence them. We attach a filter
+    to the root logger AND its handlers for the duration of the block, then
+    remove it — without changing levels (real errors still propagate).
+    """
+    root = logging.getLogger()
+    flt = _DropMessagesFilter(needles)
+    root.addFilter(flt)
+    handlers = list(root.handlers)
+    for h in handlers:
+        h.addFilter(flt)
+    try:
+        yield
+    finally:
+        root.removeFilter(flt)
+        for h in handlers:
+            try:
+                h.removeFilter(flt)
+            except Exception:
+                pass
+
+
+# Map WhisperJAV language names/codes to SenseVoice language codes.
+# SenseVoice supports: zh (Chinese), en (English), yue (Cantonese),
+# ja (Japanese), ko (Korean), and "auto" / "nospeech".
+_SENSEVOICE_LANG_MAP = {
+    "japanese": "ja", "ja": "ja", "jp": "ja",
+    "english": "en", "en": "en",
+    "chinese": "zh", "zh": "zh", "mandarin": "zh",
+    "cantonese": "yue", "yue": "yue",
+    "korean": "ko", "ko": "ko",
+    "auto": "auto", "": "auto", None: "auto",
+}
+
+
+class SenseVoiceASR:
+    """SenseVoice (FunASR) ASR backend.
+
+    Lazily loads the FunASR AutoModel. ``transcribe(audio_path)`` returns a list
+    of ``{text, start, end}`` segments whose timestamps span the supplied audio
+    clip (SenseVoice does not emit reliable intra-clip timestamps; per-scene
+    granularity comes from the pipeline's scene detection).
+    """
+
+    DEFAULT_MODEL_ID = "iic/SenseVoiceSmall"
+    DEFAULT_VAD_MODEL = "fsmn-vad"
+    DEFAULT_LANGUAGE = "ja"
+
+    def __init__(
+        self,
+        model_id: str = DEFAULT_MODEL_ID,
+        device: str = "auto",
+        language: str = DEFAULT_LANGUAGE,
+        use_itn: bool = True,
+        vad_model: Optional[str] = DEFAULT_VAD_MODEL,
+        vad_max_segment_ms: int = 60000,
+        merge_vad: bool = True,
+        merge_length_s: int = 15,
+        batch_size_s: int = 60,
+        ban_emo_unk: bool = False,
+        task: str = "transcribe",
+        # Speaker diarization (funasr 1.3.9+): spk_model (cam++) clusters speaker
+        # embeddings per VAD segment so generate() returns sentence_info with
+        # per-sentence {spk, start, end}. Requires vad_model on.
+        #
+        # spk_mode="vad_segment" (NOT punc_segment): SenseVoice is non-
+        # autoregressive and emits NO word timestamps, so funasr's punc_segment
+        # mode can't run — it logs "No timestamps in ASR result (e.g.
+        # SenseVoice), falling back to vad_segment" and downgrades anyway. We
+        # request vad_segment directly so the punc_model is never needed (its
+        # text isn't even used in vad_segment mode), which removes the
+        # "length mismatch between punc and timestamp" warning spam and avoids
+        # loading/downloading ct-punc for nothing. ITN (use_itn) is a separate
+        # SenseVoice decode flag and still formats the per-speaker text.
+        diarize: bool = False,
+        spk_model: str = "cam++",
+        punc_model: Optional[str] = None,
+        spk_mode: str = "vad_segment",
+        # Force a fixed speaker count. 0/None = cam++ auto-estimates via spectral
+        # eigengap (often collapses to 1 speaker on monologue-ish/breathy audio).
+        # Set 2+ when you KNOW how many speakers a scene has and auto-detect
+        # under-segments (passed to generate() as preset_spk_num → oracle_num).
+        spk_num: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            model_id: FunASR/ModelScope model id (default iic/SenseVoiceSmall).
+            device: 'auto', 'cuda', 'cuda:N', or 'cpu'.
+            language: source language name or code; mapped to SenseVoice codes.
+            use_itn: inverse text normalization (punctuation/numbers).
+            vad_model: FunASR VAD model for long-audio chunking ('fsmn-vad'),
+                       or None to disable internal VAD.
+            vad_max_segment_ms: max single VAD segment length (ms). FunASR's
+                vad_kwargs.max_single_segment_time; the tutorial recommends
+                60000 (60s) for long audio. SenseVoice truncates segments longer
+                than this, so don't set it below your longest expected utterance.
+            merge_vad: merge short VAD segments before decoding.
+            merge_length_s: target merged-segment length (s) when merge_vad.
+            batch_size_s: dynamic batch size in audio-seconds.
+            task: 'transcribe' or 'translate'. SenseVoice has no native
+                  translation; 'translate' is accepted but only transcribes
+                  (a warning is logged). Direct-to-English should use another
+                  backend.
+        """
+        self.model_id = model_id
+        self.device_request = device
+        self.language = self._normalize_language(language)
+        self.use_itn = bool(use_itn)
+        self.vad_model = vad_model
+        self.vad_max_segment_ms = int(vad_max_segment_ms)
+        self.merge_vad = bool(merge_vad)
+        self.merge_length_s = int(merge_length_s)
+        self.batch_size_s = int(batch_size_s)
+        self.ban_emo_unk = bool(ban_emo_unk)
+        self.task = task
+        self.diarize = bool(diarize)
+        self.spk_model = spk_model
+        self.punc_model = punc_model
+        self.spk_mode = spk_mode
+        # 0 → None (auto). Only forwarded when diarizing.
+        self.spk_num = int(spk_num) if spk_num else None
+
+        if self.diarize and not self.vad_model:
+            # The spk path runs through inference_with_vadres — VAD must be on.
+            logger.warning(
+                "Diarization requires VAD; re-enabling fsmn-vad (was disabled)."
+            )
+            self.vad_model = self.DEFAULT_VAD_MODEL
+
+        if task == "translate":
+            logger.warning(
+                "SenseVoice does not support translation natively; it will "
+                "transcribe in the source language. For direct-to-English use "
+                "--mode qwen or --mode transformers instead."
+            )
+
+        # Lazily-loaded FunASR model + postprocess fn
+        self.model = None
+        self._rich_postprocess = None
+        self._device = None
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _normalize_language(language: Optional[str]) -> str:
+        key = language.lower() if isinstance(language, str) else language
+        return _SENSEVOICE_LANG_MAP.get(key, "auto")
+
+    def _detect_device(self) -> str:
+        if self.device_request and self.device_request != "auto":
+            # 'cuda' -> 'cuda:0' to match FunASR's expected format
+            if self.device_request == "cuda":
+                return "cuda:0"
+            return self.device_request
+        try:
+            import torch
+            if torch.cuda.is_available():
+                return "cuda:0"
+        except Exception:
+            pass
+        return "cpu"
+
+    @staticmethod
+    def _quiet_funasr_logging() -> None:
+        """Raise FunASR/modelscope loggers to WARNING to de-clutter the console.
+
+        FunASR emits per-call INFO lines (rtf_avg, time_speech, load_data,
+        extract_feat) on every generate(); with one call per scene this floods
+        the GUI console. We keep WARNING/ERROR so real problems still surface.
+        No-op when WhisperJAV is running at DEBUG (power users want the firehose).
+        """
+        import logging
+        if logging.getLogger("whisperjav").isEnabledFor(logging.DEBUG):
+            return
+        for name in ("funasr", "modelscope"):
+            try:
+                logging.getLogger(name).setLevel(logging.WARNING)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------ #
+    # Model lifecycle
+    # ------------------------------------------------------------------ #
+    def load_model(self) -> None:
+        """Lazily construct the FunASR AutoModel. Idempotent."""
+        if self.model is not None:
+            logger.debug("SenseVoice model already loaded")
+            return
+
+        try:
+            from funasr import AutoModel
+            from funasr.utils.postprocess_utils import rich_transcription_postprocess
+        except ImportError as e:
+            raise ImportError(
+                "SenseVoice requires the 'funasr' package, which is not installed.\n"
+                "Install it with:\n\n"
+                "    pip install funasr\n\n"
+                "(funasr also pulls in modelscope/onnxruntime; first run will "
+                "download the SenseVoiceSmall model ~1GB.)\n"
+                f"Original import error: {e}"
+            ) from e
+
+        self._rich_postprocess = rich_transcription_postprocess
+        self._device = self._detect_device()
+
+        # Quiet FunASR's chatty per-call INFO logging (rtf_avg / time_speech /
+        # load_data / extract_feat lines) so the GUI console stays readable.
+        # Skipped when WhisperJAV is in DEBUG so power users can still see it.
+        self._quiet_funasr_logging()
+
+        logger.info("Loading SenseVoice ASR model (FunASR)...")
+        logger.info(f"  Model:    {self.model_id}")
+        logger.info(f"  Device:   {self._device}")
+        logger.info(f"  Language: {self.language}")
+        logger.info(f"  VAD:      {self.vad_model or 'disabled'}")
+
+        model_kwargs: Dict[str, Any] = {
+            "model": self.model_id,
+            "trust_remote_code": False,  # use the funasr-packaged model.py
+            "device": self._device,
+            "disable_update": True,      # don't phone home for version checks
+            # Suppress FunASR's per-call tqdm progress bars (rtf_avg/load_data/
+            # extract_feat/[====] bars). These redraw once per scene and clutter
+            # the GUI console without adding info. Normal log lines are kept.
+            #
+            # EXCEPTION: in diarization mode we transcribe the WHOLE file in one
+            # generate() call (no per-scene loop to report progress), so funasr's
+            # internal per-VAD-chunk bar is the only sign of life — keep it on.
+            "disable_pbar": not self.diarize,
+        }
+        if self.vad_model:
+            model_kwargs["vad_model"] = self.vad_model
+            model_kwargs["vad_kwargs"] = {"max_single_segment_time": self.vad_max_segment_ms}
+
+        if self.diarize:
+            # Speaker diarization: spk_model (cam++) clusters speaker embeddings
+            # per VAD segment. punc_model is left off for SenseVoice — vad_segment
+            # mode doesn't use it (see __init__ note). ITN still formats the text.
+            model_kwargs["spk_model"] = self.spk_model
+            model_kwargs["spk_mode"] = self.spk_mode
+            if self.punc_model:
+                model_kwargs["punc_model"] = self.punc_model
+            logger.info(
+                f"  Diarization: ON (spk={self.spk_model}, punc={self.punc_model}, "
+                f"mode={self.spk_mode})"
+            )
+
+        start = time.time()
+        try:
+            self.model = AutoModel(**model_kwargs)
+        except Exception as e:
+            logger.error(f"Failed to load SenseVoice model '{self.model_id}': {e}")
+            raise
+        logger.info(f"  Loaded in {time.time() - start:.1f}s")
+
+    # ------------------------------------------------------------------ #
+    # Transcription
+    # ------------------------------------------------------------------ #
+    def transcribe(
+        self,
+        audio_path: Path,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Transcribe one audio file/clip.
+
+        Returns a list of ``{text, start, end}`` segments. Because SenseVoice
+        returns merged-utterance text without reliable intra-clip timestamps,
+        the segment(s) span the full clip duration; finer timing comes from the
+        pipeline's scene splitting.
+        """
+        audio_path = Path(audio_path)
+        if self.model is None:
+            self.load_model()
+
+        if progress_callback:
+            progress_callback(0.0, f"Transcribing: {audio_path.name}")
+
+        duration = self._probe_duration(audio_path)
+
+        logger.debug(f"SenseVoice transcribing: {audio_path.name} "
+                     f"(lang={self.language}, dur={duration:.2f}s)")
+
+        def _generate():
+            gen_kwargs = dict(
+                input=str(audio_path),
+                cache={},
+                language=self.language,
+                use_itn=self.use_itn,
+                batch_size_s=self.batch_size_s,
+                merge_vad=self.merge_vad,
+                merge_length_s=self.merge_length_s,
+                ban_emo_unk=self.ban_emo_unk,
+            )
+            # Force a fixed speaker count (cam++ auto-estimate often collapses to
+            # 1 on monologue-ish/breathy audio). funasr maps preset_spk_num →
+            # cluster oracle_num. Only meaningful while diarizing.
+            if self.diarize and self.spk_num:
+                gen_kwargs["preset_spk_num"] = self.spk_num
+            if self.diarize:
+                # In vad_segment mode (our SenseVoice setup, no punc_model) funasr
+                # unconditionally logs `ERROR:root:Missing punc_model, which is
+                # required by spk_model.` even though diarization then completes
+                # fine via the vad_segment path. It's a bare logging.error on the
+                # ROOT logger, so our funasr/modelscope quieting doesn't catch it.
+                # Filter only that exact benign line for the duration of the call
+                # so users don't see a scary ERROR for a working run.
+                with _suppress_root_log_messages(_BENIGN_FUNASR_DIARIZE_MSGS):
+                    return self.model.generate(**gen_kwargs)
+            return self.model.generate(**gen_kwargs)
+
+        try:
+            res = _generate()
+        except Exception as e:
+            # funasr's diarization/punc alignment can throw on some audio
+            # (e.g. "'>' not supported between float and NoneType" when the
+            # punc/timestamp lengths mismatch). Rather than fail the whole file,
+            # fall back to a plain (non-diarized) decode for this call.
+            if self.diarize:
+                logger.warning(
+                    f"Diarized generate() failed for {audio_path.name} ({e}); "
+                    f"retrying without diarization."
+                )
+                self._disable_diarization_runtime()
+                try:
+                    res = _generate()
+                except Exception as e2:
+                    logger.error(f"SenseVoice generate() failed for {audio_path.name}: {e2}")
+                    raise
+            else:
+                logger.error(f"SenseVoice generate() failed for {audio_path.name}: {e}")
+                raise
+
+        segments = self._result_to_segments(res, duration)
+
+        if progress_callback:
+            progress_callback(1.0, "Transcription complete")
+
+        logger.debug(f"SenseVoice produced {len(segments)} segment(s) for {audio_path.name}")
+        return segments
+
+    def _result_to_segments(self, res: Any, duration: float) -> List[Dict[str, Any]]:
+        """Convert FunASR generate() output into {text, start, end} segments.
+
+        FunASR returns a list of dicts (one per input). Each dict's 'text'
+        carries SenseVoice rich tokens which we strip via
+        rich_transcription_postprocess. If a per-utterance 'timestamp' field is
+        present (some FunASR builds expose it), we use it; otherwise we span the
+        clip.
+        """
+        if not res:
+            return []
+
+        # Diarization path: each result carries 'sentence_info' — a list of
+        # {text, start, end, spk, timestamp} with REAL per-sentence timestamps
+        # and speaker ids. Prefer it when present; one segment per sentence.
+        if self.diarize:
+            diar_segments = self._sentence_info_to_segments(res)
+            if diar_segments:
+                return diar_segments
+            logger.warning(
+                "Diarization on but no sentence_info returned; "
+                "falling back to clip-span segmentation."
+            )
+
+        segments: List[Dict[str, Any]] = []
+        n = len(res)
+        for i, item in enumerate(res):
+            raw_text = item.get("text", "") if isinstance(item, dict) else str(item)
+            text = self._rich_postprocess(raw_text).strip() if raw_text else ""
+            if not text:
+                continue
+
+            # Prefer explicit per-utterance timestamps when available. Accept
+            # only a flat 2-number [start, end] pair — NOT word-level timestamp
+            # lists (which output_timestamp=True produces: [[s,e],[s,e],...],
+            # and which can coincidentally have len==2). Anything else falls
+            # through to even clip-spanning.
+            ts = item.get("timestamp") if isinstance(item, dict) else None
+            start = end = None
+            if (ts and isinstance(ts, (list, tuple)) and len(ts) == 2
+                    and all(isinstance(x, (int, float)) for x in ts)):
+                start, end = float(ts[0]) / 1000.0, float(ts[1]) / 1000.0
+            if start is None or end is None:
+                # Spread evenly across the clip when multiple items, else span all.
+                start = (duration * i / n) if n > 1 else 0.0
+                end = (duration * (i + 1) / n) if n > 1 else (duration or start + 2.0)
+
+            segments.append({"text": text, "start": float(start), "end": float(end)})
+
+        return segments
+
+    def _disable_diarization_runtime(self) -> None:
+        """Turn diarization off on the live model after a funasr diarize failure.
+
+        Detaches spk_model/punc_model from the loaded AutoModel so a retry
+        decodes plainly, and clears self.diarize so _result_to_segments uses the
+        clip-span path. Idempotent and best-effort.
+        """
+        self.diarize = False
+        for attr in ("spk_model", "punc_model"):
+            try:
+                if getattr(self.model, attr, None) is not None:
+                    setattr(self.model, attr, None)
+            except Exception:
+                pass
+
+    def _sentence_info_to_segments(self, res: Any) -> List[Dict[str, Any]]:
+        """Convert funasr diarization 'sentence_info' into speaker-tagged segments.
+
+        Each sentence_info entry has start/end (milliseconds), an integer ``spk``
+        id, and the text under ``sentence`` (vad_segment mode, the SenseVoice
+        path) or ``text`` (punc_segment mode). We strip rich tokens and prefix
+        the speaker as ``[spkN] text`` so the label survives into the SRT.
+        Returns [] if no usable sentence_info is present.
+        """
+        segments: List[Dict[str, Any]] = []
+        for item in res:
+            if not isinstance(item, dict):
+                continue
+            sinfo = item.get("sentence_info")
+            if not sinfo or not isinstance(sinfo, (list, tuple)):
+                continue
+            for sent in sinfo:
+                if not isinstance(sent, dict):
+                    continue
+                # funasr writes the per-sentence text under DIFFERENT keys
+                # depending on spk_mode: "sentence" in vad_segment mode (the
+                # SenseVoice path — auto_model.py:842) vs "text" in punc_segment
+                # mode (timestamp_sentence). Accept both.
+                raw_text = sent.get("sentence") or sent.get("text") or ""
+                text = self._rich_postprocess(raw_text).strip() if raw_text else ""
+                if not text:
+                    continue
+                # funasr sentence_info start/end are in milliseconds.
+                start = float(sent.get("start", 0) or 0) / 1000.0
+                end = float(sent.get("end", 0) or 0) / 1000.0
+                if end <= start:
+                    end = start + 0.1
+                spk = sent.get("spk")
+                if spk is not None:
+                    text = f"[spk{spk}] {text}"
+                segments.append({"text": text, "start": start, "end": end})
+        return segments
+
+    @staticmethod
+    def _probe_duration(audio_path: Path) -> float:
+        """Best-effort audio duration in seconds (0.0 if unknown)."""
+        try:
+            import soundfile as sf
+            info = sf.info(str(audio_path))
+            if info.samplerate:
+                return float(info.frames) / float(info.samplerate)
+        except Exception as e:
+            logger.debug(f"Could not probe duration for {audio_path}: {e}")
+        return 0.0
+
+    # ------------------------------------------------------------------ #
+    # Cleanup
+    # ------------------------------------------------------------------ #
+    def unload_model(self) -> None:
+        """Free the model and GPU memory."""
+        if self.model is not None:
+            logger.debug("Unloading SenseVoice model...")
+            try:
+                del self.model
+            except Exception as e:
+                logger.warning(f"Error deleting SenseVoice model: {e}")
+            finally:
+                self.model = None
+            import gc
+            try:
+                gc.collect()
+            except Exception:
+                pass
+            # CUDA cache cleanup is handled by the caller (safe_cuda_cleanup).
+            logger.debug("SenseVoice model unloaded")
+
+    def cleanup(self) -> None:
+        """Alias for unload_model()."""
+        self.unload_model()
+
+    def __del__(self):
+        try:
+            self.unload_model()
+        except Exception:
+            pass

--- a/whisperjav/modules/speech_enhancement/backends/bs_roformer.py
+++ b/whisperjav/modules/speech_enhancement/backends/bs_roformer.py
@@ -16,6 +16,7 @@ at 44.1kHz. For speech-only content, ClearVoice may be more appropriate.
 
 from typing import Union, List, Dict, Any, Optional
 from pathlib import Path
+import sys
 import time
 import tempfile
 import numpy as np
@@ -49,6 +50,33 @@ DEFAULT_MODEL = "vocals"
 DEFAULT_SAMPLE_RATE = 44100
 
 
+class _FilteredStdout:
+    """stdout proxy used during demix_track().
+
+    Keeps useful progress (the one-shot "Estimated total processing time..."
+    line) but drops the per-chunk carriage-return redraw spam
+    ("Estimated time remaining...") that otherwise stacks up in piped logs.
+    """
+
+    _DROP = "Estimated time remaining"
+
+    def __init__(self):
+        self._real = sys.__stdout__
+
+    def write(self, s):
+        try:
+            if s and self._DROP not in s:
+                self._real.write(s)
+        except Exception:
+            pass
+
+    def flush(self):
+        try:
+            self._real.flush()
+        except Exception:
+            pass
+
+
 class BSRoformerSpeechEnhancer:
     """
     BS-RoFormer vocal isolation backend.
@@ -69,20 +97,43 @@ class BSRoformerSpeechEnhancer:
         self,
         model: str = DEFAULT_MODEL,
         device: str = "auto",
+        ckpt_path: Optional[str] = None,
+        config_path: Optional[str] = None,
+        variant: str = "revive2",
+        num_overlap: Optional[int] = None,
         **kwargs
     ):
         """
         Initialize BS-RoFormer enhancer.
 
         Args:
-            model: Model/stem to extract ("vocals" or "other")
-            device: Device to use ("cuda", "cpu", "auto")
-            **kwargs: Additional parameters (ignored)
+            model: Stem to extract ("vocals" or "other").
+            device: Device to use ("cuda", "cpu", "auto").
+            ckpt_path: Optional explicit path to a .ckpt (overrides download).
+            config_path: Optional explicit path to the model config .yaml.
+            variant: Which pcunwa BS-Roformer-Revive model to auto-download when
+                ckpt_path is not given — "revive2" (best Bleedless, recommended for
+                ASR), "revive3e" (max Fullness), or "revive" (v1). Bleedless wins
+                for transcription: cleanest vocal stem = best ASR input.
+            **kwargs: Additional parameters (ignored).
         """
         self._model_name = model if model in _MODEL_INFO else DEFAULT_MODEL
         self._device = device
+        self._ckpt_path = ckpt_path
+        self._config_path = config_path
+        self._variant = (variant or "revive2").lower()
+        # num_overlap: chunk overlap during separation. Higher = better quality
+        # but slower (config default is 2). Lower (e.g. 1) ~halves separation time
+        # at a small quality cost. None = use the model config's value.
+        try:
+            self._num_overlap = int(num_overlap) if num_overlap is not None else None
+        except (TypeError, ValueError):
+            self._num_overlap = None
         self._separator = None
         self._initialized = False
+        self._config = None
+        self._device_torch = None
+        self._target_instrument = None
 
         if model not in _MODEL_INFO:
             logger.warning(
@@ -92,9 +143,73 @@ class BSRoformerSpeechEnhancer:
 
         logger.debug(f"BSRoformerSpeechEnhancer configured: model={self._model_name}")
 
+    # Public BS-Roformer-Revive mirror (the package's own registry URLs are dead).
+    # Revive 2 = best Bleedless (cleanest stem → best ASR input, our default).
+    _HF_BASE = "https://huggingface.co/pcunwa/BS-Roformer-Revive/resolve/main/"
+    _VARIANT_CKPT = {
+        "revive": "bs_roformer_revive.ckpt",
+        "revive2": "bs_roformer_revive2.ckpt",
+        "revive3e": "bs_roformer_revive3e.ckpt",
+    }
+    _CONFIG_FILE = "config.yaml"
+
+    def _resolve_assets(self):
+        """Return (ckpt_path, config_path) as Paths, or (None, None) on failure.
+
+        Resolution order: explicit user paths -> cache -> download from HF.
+        """
+        from pathlib import Path
+        # 1) explicit paths
+        if self._ckpt_path and self._config_path:
+            cp, gp = Path(self._ckpt_path), Path(self._config_path)
+            if cp.exists() and gp.exists():
+                logger.info(f"BS-RoFormer: using explicit checkpoint {cp.name}")
+                return cp, gp
+            logger.warning("BS-RoFormer explicit ckpt/config path missing; falling back to download")
+
+        variant = self._variant if self._variant in self._VARIANT_CKPT else "revive2"
+        ckpt_name = self._VARIANT_CKPT[variant]
+        cache_dir = Path.home() / ".cache" / "whisperjav" / "bs_roformer" / variant
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        ckpt_path = cache_dir / ckpt_name
+        cfg_path = cache_dir / self._CONFIG_FILE
+
+        # 2) cache
+        if ckpt_path.exists() and cfg_path.exists():
+            return ckpt_path, cfg_path
+
+        # 3) download
+        import urllib.request
+        try:
+            if not cfg_path.exists():
+                logger.info(f"Downloading BS-RoFormer config -> {cfg_path}")
+                urllib.request.urlretrieve(self._HF_BASE + self._CONFIG_FILE, str(cfg_path))
+            if not ckpt_path.exists():
+                logger.info(f"Downloading BS-RoFormer weights ({variant}, ~639MB) -> {ckpt_path} (first run only)")
+                urllib.request.urlretrieve(self._HF_BASE + ckpt_name, str(ckpt_path))
+        except Exception as e:
+            logger.error(f"BS-RoFormer download failed: {e}")
+            # Clean partial files so a retry re-downloads cleanly.
+            for p in (ckpt_path, cfg_path):
+                try:
+                    if p.exists() and p.stat().st_size == 0:
+                        p.unlink()
+                except Exception:
+                    pass
+            return None, None
+
+        if ckpt_path.exists() and cfg_path.exists():
+            return ckpt_path, cfg_path
+        return None, None
+
     def _ensure_initialized(self) -> bool:
         """
         Lazy initialization of BS-RoFormer model.
+
+        Uses the real bs-roformer-infer (>=0.1.0) API: download the model
+        checkpoint+config from the registry, build the net via
+        get_model_from_config, load weights, and move to device. Separation
+        itself is done later via demix_track() (see _process_audio).
 
         Returns:
             True if initialized successfully, False otherwise
@@ -103,37 +218,70 @@ class BSRoformerSpeechEnhancer:
             return True
 
         try:
-            # Import bs-roformer
-            from bs_roformer import BSRoformer
+            import torch
+            import yaml
+            from ml_collections import ConfigDict
+            from bs_roformer.utils import get_model_from_config
+            from bs_roformer.inference import SafeLoaderWithTuple
+        except ImportError as e:
+            logger.error(f"bs-roformer not installed or incompatible: {e}")
+            logger.error("Install with: pip install bs-roformer-infer")
+            return False
 
-            logger.info(f"Loading BS-RoFormer model for stem: {self._model_name}")
+        try:
+            # Resolve ckpt + config. The bs-roformer-infer registry URLs are all
+            # dead upstream (gated/401 or 404), so we self-host the download from
+            # the public pcunwa/BS-Roformer-Revive HF repo. Order:
+            #   1) explicit ckpt_path/config_path (user-supplied)
+            #   2) cached file from a previous run
+            #   3) download the selected Revive variant from HF
+            ckpt_path, cfg_path = self._resolve_assets()
+            if ckpt_path is None or cfg_path is None:
+                logger.error("BS-RoFormer model assets unavailable (download failed)")
+                return False
+            logger.info(f"Loading BS-RoFormer model (variant={self._variant}, stem={self._model_name})")
 
-            # Resolve best available device (cuda > mps > cpu)
+            # Load config + build model.
+            with open(cfg_path) as f:
+                self._config = ConfigDict(yaml.load(f, Loader=SafeLoaderWithTuple))
+
+            # Override chunk overlap if requested (speed/quality knob).
+            if self._num_overlap is not None:
+                ov = max(1, self._num_overlap)
+                try:
+                    if hasattr(self._config, "inference"):
+                        self._config.inference.num_overlap = ov
+                    logger.info(f"BS-RoFormer: num_overlap overridden to {ov} (config default was 2)")
+                except Exception as e:
+                    logger.warning(f"Could not set num_overlap={ov}: {e}")
+
+            model = get_model_from_config("bs_roformer", self._config)
+            if model is None:
+                logger.error("get_model_from_config returned None for bs_roformer")
+                return False
+            state = torch.load(str(ckpt_path), map_location=torch.device("cpu"))
+            model.load_state_dict(state)
+
+            # Resolve device (cuda > cpu; bs-roformer is heavy, MPS unsupported here).
             device = resolve_torch_device(self._device)
+            if device == "mps":
+                logger.info("BS-RoFormer: MPS not supported, using CPU")
+                device = "cpu"
+            self._device_torch = torch.device(device)
+            model = model.to(self._device_torch)
+            model.eval()
+            self._separator = model
 
-            # Try initializing with the selected device
-            try:
-                self._separator = BSRoformer(device=device)
-            except Exception as dev_err:
-                # If MPS failed (model may not support all ops), fall back to CPU
-                if device == "mps":
-                    logger.info(
-                        f"BS-RoFormer does not support MPS ({dev_err}), "
-                        "falling back to CPU"
-                    )
-                    device = "cpu"
-                    self._separator = BSRoformer(device=device)
-                else:
-                    raise
+            # Which instrument to keep (vocals for speech isolation).
+            self._target_instrument = (
+                getattr(self._config.training, "target_instrument", None)
+                or self._model_name
+            )
 
             self._initialized = True
             logger.info(f"BS-RoFormer loaded successfully on {device}")
             return True
 
-        except ImportError as e:
-            logger.error(f"bs-roformer not installed: {e}")
-            logger.error("Install with: pip install bs-roformer-infer")
-            return False
         except Exception as e:
             logger.error(f"Failed to initialize BS-RoFormer: {e}")
             return False
@@ -247,46 +395,50 @@ class BSRoformerSpeechEnhancer:
         Returns:
             Separated audio array (vocals or other stem)
         """
+        import torch
+        from bs_roformer.utils import demix_track
+
         stem = _MODEL_INFO[self._model_name]["stem"]
 
-        # BS-RoFormer expects stereo input, convert mono to stereo
+        # BS-RoFormer expects stereo (channels, samples). Build it.
         if audio.ndim == 1:
             audio_stereo = np.stack([audio, audio], axis=0)  # (2, samples)
         else:
             audio_stereo = audio
+            # Normalize to (channels, samples)
+            if audio_stereo.shape[0] > audio_stereo.shape[1]:
+                audio_stereo = audio_stereo.T
+            if audio_stereo.shape[0] == 1:
+                audio_stereo = np.repeat(audio_stereo, 2, axis=0)
 
-        # Ensure shape is (channels, samples)
-        if audio_stereo.shape[0] > audio_stereo.shape[1]:
-            audio_stereo = audio_stereo.T
+        mixture = torch.tensor(audio_stereo, dtype=torch.float32)
 
-        # Process through separator
-        # API: separator.separate(audio, sr) -> dict of stems
-        result = self._separator.separate(audio_stereo, sr=sample_rate)
+        # demix_track returns ({instrument: ndarray(channels, samples)}, _).
+        # The package writes progress to stdout: a useful one-shot ETA line
+        # ("Estimated total processing time...") plus a per-chunk redraw spam
+        # ("Estimated time remaining...", carriage-return based) that stacks up
+        # in a piped log. Filter: keep the useful ETA, drop the \r redraw spam.
+        import contextlib
+        with contextlib.redirect_stdout(_FilteredStdout()):
+            res, _ = demix_track(self._config, self._separator, mixture, self._device_torch)
 
-        # Extract the desired stem
-        if isinstance(result, dict):
-            if stem in result:
-                separated = result[stem]
-            elif "vocals" in result and stem == "vocals":
-                separated = result["vocals"]
-            else:
-                # Take first available
-                separated = list(result.values())[0]
+        if stem in res:
+            separated = res[stem]
+        elif self._target_instrument in res:
+            separated = res[self._target_instrument]
         else:
-            separated = result
+            separated = list(res.values())[0]
 
-        # Convert to mono if stereo
+        # demix_track output is (channels, samples) -> collapse to mono.
         if isinstance(separated, np.ndarray):
             if separated.ndim > 1:
-                # Average channels for mono
-                if separated.shape[0] <= 2:  # (channels, samples)
+                if separated.shape[0] <= 2:      # (channels, samples)
                     separated = np.mean(separated, axis=0)
-                else:  # (samples, channels)
+                else:                             # (samples, channels)
                     separated = np.mean(separated, axis=1)
-
             return separated.astype(np.float32)
 
-        raise RuntimeError(f"Unexpected result type from BS-RoFormer: {type(result)}")
+        raise RuntimeError(f"Unexpected result type from BS-RoFormer: {type(separated)}")
 
     def get_preferred_sample_rate(self) -> int:
         """Return 44100Hz (standard for music/BS-RoFormer)."""

--- a/whisperjav/modules/srt_postprocessing.py
+++ b/whisperjav/modules/srt_postprocessing.py
@@ -112,9 +112,17 @@ class SRTPostProcessor:
         # Korean and Chinese use the same sanitizer - Japanese-specific patterns
         # simply won't match Hangul/Han characters and pass through unchanged
         if language in ('ja', 'ko', 'zh'):
+            # remove_hallucinations gates all three phrase-matching modes
+            # (exact/regex/fuzzy); remove_cps_outliers gates the abnormal-CPS
+            # drop. Non-autoregressive backends (SenseVoice) pass these False to
+            # avoid Whisper-tuned filters dropping their per-scene short lines.
+            _hall = kwargs.get('remove_hallucinations', True)
             config = SanitizationConfig(
-                enable_exact_matching=kwargs.get('remove_hallucinations', True),
+                enable_exact_matching=_hall,
+                enable_regex_matching=_hall,
+                enable_fuzzy_matching=_hall,
                 enable_repetition_cleaning=kwargs.get('remove_repetitions', True),
+                enable_cps_filter=kwargs.get('remove_cps_outliers', True),
                 repetition_threshold=kwargs.get('repetition_threshold', 2),
                 min_subtitle_duration=kwargs.get('min_subtitle_duration', 0.5),
                 max_subtitle_duration=kwargs.get('max_subtitle_duration', 7.0),

--- a/whisperjav/modules/subtitle_sanitizer.py
+++ b/whisperjav/modules/subtitle_sanitizer.py
@@ -902,21 +902,25 @@ class SubtitleSanitizer:
 
 
 
-            # Hallucination Removal
+            # Hallucination Removal (gated — non-autoregressive backends like
+            # SenseVoice disable this; their short utterances collide with the
+            # Whisper-tuned blacklist).
 
-            modified_text, hall_mods = self.hallucination_remover.remove_hallucinations(modified_text, self.config.primary_language)
+            if self.config.enable_exact_matching or self.config.enable_regex_matching or self.config.enable_fuzzy_matching:
 
-            if hall_mods:
+                modified_text, hall_mods = self.hallucination_remover.remove_hallucinations(modified_text, self.config.primary_language)
 
-                all_mods.extend(hall_mods)
+                if hall_mods:
 
-                final_reason = "hallucination"
+                    all_mods.extend(hall_mods)
+
+                    final_reason = "hallucination"
 
 
 
             # Repetition Cleaning
 
-            if modified_text.strip(): # Only process if there's text left
+            if self.config.enable_repetition_cleaning and modified_text.strip(): # Only process if there's text left
 
                 modified_text, rep_mods = self.repetition_cleaner.clean_repetitions(modified_text)
 
@@ -971,9 +975,20 @@ class SubtitleSanitizer:
 
 
 
-        # Now, run the High CPS removal on the already cleaned text
+        # Now, run the High CPS removal on the already cleaned text.
+        # Skippable: SenseVoice and other non-autoregressive backends span a
+        # whole utterance across the scene duration, so genuine short lines read
+        # as "abnormally slow" and would be dropped here. (#350)
 
-        final_subs = self._remove_abnormally_fast_subs(cleaned_subs)
+        if getattr(self.config, 'enable_cps_filter', True):
+
+            final_subs = self._remove_abnormally_fast_subs(cleaned_subs)
+
+        else:
+
+            logger.debug("CPS filter disabled (enable_cps_filter=False) — keeping all cleaned subs")
+
+            final_subs = cleaned_subs
 
         logger.debug(f"Content Cleaning complete. Subtitles remaining: {len(final_subs)}")
 

--- a/whisperjav/pipelines/sensevoice_pipeline.py
+++ b/whisperjav/pipelines/sensevoice_pipeline.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+SenseVoice Pipeline for WhisperJAV (issue #350).
+
+Drop-in ASR mode built on the FunASR SenseVoiceSmall model. SenseVoice is a
+fast non-autoregressive recognizer with strong Japanese support and built-in
+audio-event tagging, at ~1GB VRAM.
+
+Flow (mirrors TransformersPipeline, trimmed):
+    1. Extract audio (16kHz mono)
+    2. Optional scene detection (none / auditok / silero / semantic)
+    3. Transcribe each scene with SenseVoiceASR
+    4. Build per-scene SRT, stitch with scene offsets
+    5. SRT post-processing
+    6. Return master metadata
+
+Scene detection supplies subtitle granularity because SenseVoice returns
+merged-utterance text without reliable intra-clip timestamps. With scene
+detection disabled the whole file becomes a small number of subtitles.
+
+funasr is an optional dependency; it is only imported when the ASR actually
+loads (see modules/sensevoice_asr.py).
+"""
+
+import shutil
+import time
+from datetime import timedelta
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import srt
+
+from whisperjav.pipelines.base_pipeline import BasePipeline
+from whisperjav.modules.audio_extraction import AudioExtractor
+from whisperjav.modules.sensevoice_asr import SenseVoiceASR
+from whisperjav.modules.srt_postprocessing import SRTPostProcessor, normalize_language_code
+from whisperjav.modules.srt_stitching import SRTStitcher
+from whisperjav.modules.speech_enhancement import (
+    create_enhancer_direct,
+    enhance_scenes,
+    enhance_single_audio,
+    get_extraction_sample_rate,
+    is_passthrough_backend,
+)
+from whisperjav.utils.logger import logger
+from whisperjav.utils.progress_display import DummyProgress
+
+
+class SenseVoicePipeline(BasePipeline):
+    """SenseVoice (FunASR) ASR pipeline."""
+
+    VALID_SCENE_METHODS = ("none", "auditok", "silero", "semantic")
+
+    def __init__(
+        self,
+        output_dir: str,
+        temp_dir: str,
+        keep_temp_files: bool = False,
+        save_metadata_json: bool = False,
+        progress_display=None,
+        # SenseVoice ASR config
+        sv_model_id: str = "iic/SenseVoiceSmall",
+        sv_device: str = "auto",
+        sv_language: str = "ja",
+        sv_use_itn: bool = True,
+        sv_vad_model: Optional[str] = "fsmn-vad",
+        sv_scene: str = "auditok",
+        sv_task: str = "transcribe",
+        # Speech enhancement (issue #350) — e.g. bs-roformer vocal isolation.
+        # Cleans audio BEFORE SenseVoice sees it (helps noisy/music scenes).
+        sv_speech_enhancer: str = "none",
+        sv_speech_enhancer_model: Optional[str] = None,
+        sv_bsrf_overlap: Optional[int] = None,
+        # Customize-modal params (issue #350)
+        sv_ban_emo_unk: bool = False,
+        sv_merge_vad: bool = True,
+        sv_merge_length_s: int = 15,
+        sv_vad_max_segment_ms: int = 60000,
+        sv_batch_size_s: int = 60,
+        # Post-processing controls (issue #350). The shared SubtitleSanitizer is
+        # tuned for Whisper's failure modes and over-removes SenseVoice output:
+        # SenseVoice emits one line per scene spanning the whole scene duration,
+        # so genuine short lines look "abnormally slow" and its short utterances
+        # collide with the Whisper hallucination blacklist. Defaults are relaxed
+        # for SenseVoice; power users can re-enable each filter.
+        sv_remove_hallucinations: bool = False,
+        sv_remove_repetitions: bool = True,
+        sv_remove_cps_outliers: bool = False,
+        # Speaker diarization (funasr 1.3.9+): per-sentence [spkN] labels.
+        sv_diarize: bool = False,
+        sv_spk_num: Optional[int] = None,  # force N speakers (0/None = auto)
+        subs_language: str = "native",
+        **kwargs,
+    ):
+        super().__init__(
+            output_dir=output_dir,
+            temp_dir=temp_dir,
+            keep_temp_files=keep_temp_files,
+            save_metadata_json=save_metadata_json,
+            **kwargs,
+        )
+
+        self.progress = progress_display or DummyProgress()
+        self.subs_language = subs_language
+
+        # Output language code
+        if subs_language == "direct-to-english":
+            # SenseVoice can't translate; honour the requested code but warn.
+            logger.warning(
+                "SenseVoice does not translate; 'direct-to-english' will still "
+                "produce source-language text. Use --mode qwen/transformers for "
+                "English output."
+            )
+            self.lang_code = "en"
+        else:
+            self.lang_code = normalize_language_code(sv_language or "ja")
+
+        # Diarization runs on the WHOLE file (funasr's own VAD segments it) so
+        # cam++ produces globally-consistent speaker ids. Per-scene diarization
+        # is meaningless (ids reset every clip) AND crashes funasr on tiny clips,
+        # so when diarize is on we force scene detection OFF.
+        self.diarize = bool(sv_diarize)
+
+        # Scene detection
+        self.scene_method = sv_scene
+        if self.scene_method not in self.VALID_SCENE_METHODS:
+            raise ValueError(
+                f"Invalid scene method: {self.scene_method}. "
+                f"Must be one of {self.VALID_SCENE_METHODS}"
+            )
+        if self.diarize and self.scene_method != "none":
+            logger.info(
+                "Diarization ON — disabling scene detection; SenseVoice runs "
+                "on the full audio so speaker ids stay consistent."
+            )
+            self.scene_method = "none"
+
+        # Speech enhancement CONFIG (enhancer model created in process()).
+        # Extract at 48kHz for a real enhancer, 16kHz for passthrough/none.
+        self._enhancer_config = {
+            "backend": sv_speech_enhancer or "none",
+            "model": sv_speech_enhancer_model,
+        }
+        # BS-RoFormer overlap knob — only forwarded to the enhancer factory.
+        self._bsrf_overlap = sv_bsrf_overlap
+        self._enhancer_is_passthrough = is_passthrough_backend(self._enhancer_config["backend"])
+        extraction_sr = get_extraction_sample_rate(self._enhancer_config["backend"])
+        self.audio_extractor = AudioExtractor(sample_rate=extraction_sr)
+
+        self.scene_detector = None
+        if self.scene_method != "none":
+            from whisperjav.modules.scene_detection_backends import SceneDetectorFactory
+            self.scene_detector = SceneDetectorFactory.safe_create_from_legacy_kwargs(
+                method=self.scene_method
+            )
+
+        # ASR CONFIG (model created in process() as a local var, VRAM-scoped)
+        self._asr_config = {
+            "model_id": sv_model_id,
+            "device": sv_device,
+            "language": sv_language,
+            "use_itn": sv_use_itn,
+            "vad_model": sv_vad_model,
+            "task": sv_task,
+            "ban_emo_unk": sv_ban_emo_unk,
+            "merge_vad": sv_merge_vad,
+            "merge_length_s": sv_merge_length_s,
+            "vad_max_segment_ms": sv_vad_max_segment_ms,
+            "batch_size_s": sv_batch_size_s,
+            "diarize": sv_diarize,
+            "spk_num": sv_spk_num,
+        }
+        self.sv_config = dict(self._asr_config)
+
+        self.stitcher = SRTStitcher()
+        self.postprocessor = SRTPostProcessor(
+            language=self.lang_code,
+            remove_hallucinations=sv_remove_hallucinations,
+            remove_repetitions=sv_remove_repetitions,
+            remove_cps_outliers=sv_remove_cps_outliers,
+        )
+
+        logger.info("SenseVoicePipeline initialized")
+        logger.info(f"  Model: {sv_model_id}")
+        logger.info(f"  Language: {sv_language}")
+        logger.info(f"  Scene detection: {self.scene_method}")
+        logger.info(f"  Speech enhancer: {self._enhancer_config['backend']}")
+        logger.info(
+            f"  Post-proc: hallucinations={sv_remove_hallucinations} "
+            f"repetitions={sv_remove_repetitions} cps_filter={sv_remove_cps_outliers}"
+        )
+        logger.info(f"  Diarization: {sv_diarize}"
+                    + (f" (forced {sv_spk_num} speakers)" if sv_diarize and sv_spk_num else ""))
+
+    def get_mode_name(self) -> str:
+        return "sensevoice"
+
+    # ------------------------------------------------------------------ #
+    # SRT helpers (same contract as TransformersPipeline)
+    # ------------------------------------------------------------------ #
+    def _segments_to_srt(self, segments: List[Dict[str, Any]], offset: float = 0.0) -> str:
+        subtitles = []
+        for idx, seg in enumerate(segments, 1):
+            text = seg.get("text", "").strip()
+            if not text:
+                continue
+            start_sec = seg.get("start", 0.0) + offset
+            end_sec = seg.get("end", start_sec + 2.0) + offset
+            start_td = timedelta(seconds=start_sec)
+            end_td = timedelta(seconds=end_sec)
+            if end_td <= start_td:
+                end_td = start_td + timedelta(milliseconds=100)
+            subtitles.append(srt.Subtitle(index=idx, start=start_td, end=end_td, content=text))
+        return srt.compose(subtitles)
+
+    def _write_srt(self, srt_content: str, output_path: Path) -> int:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(srt_content, encoding="utf-8")
+        return srt_content.count("\n\n")
+
+    # ------------------------------------------------------------------ #
+    # Main entry
+    # ------------------------------------------------------------------ #
+    def process(self, media_info: Dict) -> Dict:
+        import os
+        start_time = time.time()
+
+        input_file = media_info["path"]
+        media_basename = media_info["basename"]
+
+        master_metadata = self.metadata_manager.create_master_metadata(
+            input_file=input_file,
+            mode=self.get_mode_name(),
+            media_info=media_info,
+        )
+        master_metadata["config"]["asr_backend"] = "sensevoice"
+        master_metadata["config"]["sensevoice_config"] = self.sv_config
+        master_metadata["config"]["scene_detection"] = self.scene_method
+
+        try:
+            # Step 1: Extract audio (16kHz mono)
+            self.progress.set_current_step("Extracting audio", 1, 5)
+            logger.info("Step 1/5: Extracting audio...")
+            audio_path = self.temp_dir / f"{media_basename}_extracted.wav"
+            extracted_audio, duration = self.audio_extractor.extract(input_file, audio_path)
+            master_metadata["input_info"]["processed_audio_file"] = str(extracted_audio)
+            master_metadata["input_info"]["audio_duration_seconds"] = duration
+            self.metadata_manager.update_processing_stage(
+                master_metadata, "audio_extraction", "completed",
+                output_path=str(audio_path), duration_seconds=duration,
+            )
+
+            # Step 2: Optional scene detection
+            scene_paths = None
+            if self.scene_method != "none":
+                self.progress.set_current_step(f"Detecting scenes ({self.scene_method})", 2, 5)
+                logger.info(f"Step 2/5: Detecting scenes ({self.scene_method})...")
+                scenes_dir = self.temp_dir / "scenes"
+                scenes_dir.mkdir(exist_ok=True)
+                detection_result = self.scene_detector.detect_scenes(
+                    extracted_audio, scenes_dir, media_basename
+                )
+                scene_paths = detection_result.to_legacy_tuples()
+                if not scene_paths:
+                    logger.warning("Scene detection produced zero scenes. Processing full audio.")
+                    scene_paths = None
+                else:
+                    master_metadata["scenes_detected"] = []
+                    for idx, (scene_path, start_sec, end_sec, dur_sec) in enumerate(scene_paths):
+                        master_metadata["scenes_detected"].append({
+                            "scene_index": idx,
+                            "filename": scene_path.name,
+                            "start_time_seconds": round(start_sec, 3),
+                            "end_time_seconds": round(end_sec, 3),
+                            "duration_seconds": round(dur_sec, 3),
+                            "path": str(scene_path),
+                        })
+                    master_metadata["summary"]["total_scenes_detected"] = len(scene_paths)
+                self.metadata_manager.update_processing_stage(
+                    master_metadata, "scene_detection", "completed",
+                    scene_count=len(scene_paths) if scene_paths else 0,
+                    method=self.scene_method,
+                )
+            else:
+                self.progress.set_current_step("Skipping scene detection", 2, 5)
+                logger.info("Step 2/5: Skipping scene detection (disabled)")
+                self.metadata_manager.update_processing_stage(
+                    master_metadata, "scene_detection", "skipped"
+                )
+
+            import gc
+            try:
+                import torch
+                _torch_available = torch.cuda.is_available()
+            except ImportError:
+                _torch_available = False
+
+            # =============================================================
+            # Step 2.5: SPEECH ENHANCEMENT (exclusive VRAM block).
+            # A real enhancer (e.g. bs-roformer) is loaded, used to clean the
+            # scene audio, then DESTROYED before the ASR loads (VRAM sandwich).
+            # "none"/passthrough just means scenes are already at 16kHz.
+            # =============================================================
+            if self._enhancer_is_passthrough:
+                logger.info("Speech enhancer is passthrough — skipping enhancement")
+                master_metadata["config"]["speech_enhancement"] = {"backend": "none", "skipped": True}
+            else:
+                _enh_kwargs = {}
+                if self._bsrf_overlap is not None:
+                    _enh_kwargs["num_overlap"] = self._bsrf_overlap
+                enhancer = create_enhancer_direct(
+                    backend=self._enhancer_config["backend"],
+                    model=self._enhancer_config["model"],
+                    **_enh_kwargs,
+                )
+                enhancer_name = enhancer.name
+                logger.info(f"Step 2.5: Preparing audio with {enhancer.display_name}...")
+                try:
+                    if scene_paths:
+                        scene_paths = enhance_scenes(
+                            scene_paths, enhancer, self.temp_dir,
+                            progress_callback=lambda n, t, name: logger.debug(
+                                f"Enhancing scene {n}/{t}: {name}"
+                            ),
+                        )
+                        master_metadata["config"]["speech_enhancement"] = {
+                            "backend": enhancer_name, "enhanced_scenes": len(scene_paths),
+                        }
+                    else:
+                        enhanced_path = self.temp_dir / f"{media_basename}_enhanced.wav"
+                        extracted_audio = enhance_single_audio(
+                            extracted_audio, enhancer, output_path=enhanced_path
+                        )
+                        master_metadata["config"]["speech_enhancement"] = {
+                            "backend": enhancer_name, "enhanced_full_audio": True,
+                        }
+                finally:
+                    # Destroy enhancer to free VRAM before SenseVoice loads.
+                    logger.debug("Destroying enhancer to free VRAM before ASR load")
+                    try:
+                        enhancer.cleanup()
+                    except Exception as e:
+                        logger.warning(f"Enhancer cleanup failed (non-fatal): {e}")
+                    del enhancer
+                    gc.collect()
+                    if _torch_available:
+                        try:
+                            torch.cuda.empty_cache()
+                        except Exception:
+                            pass
+                logger.info("Audio preparation complete, GPU memory released")
+                self.metadata_manager.update_processing_stage(
+                    master_metadata, "speech_enhancement", "completed", backend=enhancer_name,
+                )
+
+            # Step 3: ASR (VRAM-scoped local variable)
+
+            logger.info("Initializing SenseVoice ASR model (exclusive VRAM block)")
+            asr = SenseVoiceASR(**self._asr_config)
+
+            self.progress.set_current_step("Transcribing with SenseVoice", 3, 5)
+            logger.info("Step 3/5: Transcribing with SenseVoice...")
+
+            scene_srts_dir = self.temp_dir / "scene_srts"
+            scene_srts_dir.mkdir(exist_ok=True)
+
+            try:
+                if scene_paths:
+                    scene_srt_info = []
+                    total_scenes = len(scene_paths)
+                    print(f"\nTranscribing {total_scenes} scenes with SenseVoice:")
+                    transcription_start = time.time()
+
+                    for idx, (scene_path, start_sec, end_sec, dur_sec) in enumerate(scene_paths):
+                        scene_num = idx + 1
+                        progress_pct = (scene_num / total_scenes) * 100
+                        bar_width = 30
+                        filled = int(bar_width * scene_num / total_scenes)
+                        bar = "=" * filled + "-" * (bar_width - filled)
+                        eta_text = ""
+                        if scene_num > 2:
+                            elapsed = time.time() - transcription_start
+                            avg = elapsed / scene_num
+                            remaining = (total_scenes - scene_num) * avg
+                            eta_text = (f" | ETA: {remaining/60:.1f}m" if remaining > 60
+                                        else f" | ETA: {remaining:.0f}s")
+                        scene_name = (scene_path.name[:25] + "..."
+                                      if len(scene_path.name) > 25 else scene_path.name)
+                        print(f"\rTranscribing: [{bar}] {scene_num}/{total_scenes} "
+                              f"[{progress_pct:.1f}%] | {scene_name}{eta_text}", end="", flush=True)
+
+                        try:
+                            segments = asr.transcribe(scene_path)
+                            if segments:
+                                srt_content = self._segments_to_srt(segments)
+                                scene_srt_path = scene_srts_dir / f"{scene_path.stem}.srt"
+                                self._write_srt(srt_content, scene_srt_path)
+                                scene_srt_info.append((scene_srt_path, start_sec))
+                                master_metadata["scenes_detected"][idx]["transcribed"] = True
+                                master_metadata["scenes_detected"][idx]["srt_path"] = str(scene_srt_path)
+                                master_metadata["scenes_detected"][idx]["segment_count"] = len(segments)
+                            else:
+                                master_metadata["scenes_detected"][idx]["transcribed"] = True
+                                master_metadata["scenes_detected"][idx]["no_speech_detected"] = True
+                        except Exception as e:
+                            logger.error(f"Scene {scene_num} transcription failed: {e}")
+                            master_metadata["scenes_detected"][idx]["transcribed"] = False
+                            master_metadata["scenes_detected"][idx]["error"] = str(e)
+
+                    print(f"\n[DONE] Completed transcription of {total_scenes} scenes")
+
+                    self.progress.set_current_step("Stitching scene transcriptions", 4, 5)
+                    logger.info("Step 4/5: Stitching scene transcriptions...")
+                    stitched_srt_path = self.temp_dir / f"{media_basename}_stitched.srt"
+                    num_subtitles = self.stitcher.stitch(scene_srt_info, stitched_srt_path)
+                    self.metadata_manager.update_processing_stage(
+                        master_metadata, "transcription", "completed",
+                        scenes_transcribed=len(scene_srt_info),
+                    )
+                    self.metadata_manager.update_processing_stage(
+                        master_metadata, "stitching", "completed", subtitle_count=num_subtitles,
+                    )
+                else:
+                    # Full-file transcription (also the diarization path: funasr's
+                    # internal VAD chunks the whole file, so there are no scenes
+                    # to loop over and report progress from). Give the user some
+                    # sign of life since this single call can run for minutes —
+                    # funasr's own per-chunk progress bar is re-enabled for
+                    # diarization (see SenseVoiceASR), and we time the call.
+                    if self.diarize:
+                        logger.info(
+                            "Transcribing full audio with diarization (one pass; "
+                            "funasr VAD segments internally — this can take several "
+                            "minutes on a long file)..."
+                        )
+                        print("\nDiarizing full audio (single pass) — progress below:", flush=True)
+                    else:
+                        logger.info("Transcribing full audio file...")
+                    _t0 = time.time()
+                    segments = asr.transcribe(extracted_audio)
+                    _elapsed = time.time() - _t0
+                    srt_content = self._segments_to_srt(segments)
+                    stitched_srt_path = self.temp_dir / f"{media_basename}_stitched.srt"
+                    num_subtitles = self._write_srt(srt_content, stitched_srt_path)
+                    self.metadata_manager.update_processing_stage(
+                        master_metadata, "transcription", "completed", segment_count=len(segments),
+                    )
+                    self.metadata_manager.update_processing_stage(
+                        master_metadata, "stitching", "skipped",
+                    )
+                    logger.info(f"Full-audio transcription took {_elapsed:.1f}s")
+                    print(f"[DONE] Transcription complete: {len(segments)} segments "
+                          f"in {_elapsed:.1f}s")
+            finally:
+                # Destroy ASR while interpreter is stable (VRAM + safe destructor)
+                try:
+                    asr.cleanup()
+                except Exception as e:
+                    logger.warning(f"SenseVoice ASR cleanup failed (non-fatal): {e}")
+                del asr
+                gc.collect()
+                if _torch_available:
+                    try:
+                        torch.cuda.empty_cache()
+                    except Exception:
+                        pass
+
+            # Step 5: Post-process
+            self.progress.set_current_step("Post-processing subtitles", 5, 5)
+            logger.info("Step 5/5: Post-processing subtitles...")
+            final_srt_path = self.output_dir / f"{media_basename}.{self.lang_code}.whisperjav.srt"
+            processed_srt_path, stats = self.postprocessor.process(stitched_srt_path, final_srt_path)
+            if processed_srt_path != final_srt_path:
+                shutil.copy2(processed_srt_path, final_srt_path)
+
+            # Move raw_subs folder to output directory (if produced)
+            temp_raw_subs = stitched_srt_path.parent / "raw_subs"
+            if temp_raw_subs.exists():
+                final_raw_subs = self.output_dir / "raw_subs"
+                final_raw_subs.mkdir(exist_ok=True)
+                for file in temp_raw_subs.glob(f"{media_basename}*"):
+                    shutil.copy2(file, final_raw_subs / file.name)
+
+            self.metadata_manager.update_processing_stage(
+                master_metadata, "postprocessing", "completed",
+                statistics=stats, output_path=str(final_srt_path),
+            )
+            master_metadata["output_files"]["final_srt"] = str(final_srt_path)
+            master_metadata["output_files"]["stitched_srt"] = str(stitched_srt_path)
+            master_metadata["summary"]["final_subtitles_refined"] = (
+                stats.get("total_subtitles", 0) - stats.get("empty_removed", 0)
+            )
+            master_metadata["summary"]["final_subtitles_raw"] = num_subtitles
+
+            total_time = time.time() - start_time
+            master_metadata["summary"]["total_processing_time_seconds"] = round(total_time, 2)
+            master_metadata["metadata_master"]["updated_at"] = datetime.now().isoformat() + "Z"
+
+            self.metadata_manager.save_master_metadata(master_metadata, media_basename)
+            self.cleanup_temp_files(media_basename)
+
+            logger.info(f"Output saved to: {final_srt_path}")
+            logger.info(f"Total processing time: {total_time:.1f}s")
+            return master_metadata
+
+        except Exception as e:
+            self.progress.show_message(f"Pipeline error: {str(e)}", "error", 0)
+            logger.error(f"Pipeline error: {e}", exc_info=True)
+            self.metadata_manager.update_processing_stage(
+                master_metadata, "error", "failed", error_message=str(e),
+            )
+            self.metadata_manager.save_master_metadata(master_metadata, media_basename)
+            raise
+
+    def cleanup(self) -> None:
+        super().cleanup()

--- a/whisperjav/tests/test_tuner_v4_3.py
+++ b/whisperjav/tests/test_tuner_v4_3.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Test script to validate the TranscriptionTuner v4.3 implementation.
+Run this after setting up the new configuration.
+"""
+
+import sys
+import json
+from pathlib import Path
+from pprint import pprint
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from whisperjav.config.transcription_tuner import TranscriptionTuner
+from whisperjav.utils.logger import setup_logger
+
+def test_parameter_resolution():
+    """Test all pipeline/sensitivity/task combinations."""
+    
+    logger = setup_logger("test", "DEBUG")
+    
+    print("=" * 60)
+    print("Testing TranscriptionTuner v4.3 Parameter Resolution")
+    print("=" * 60)
+    
+    # Initialize tuner
+    try:
+        tuner = TranscriptionTuner()
+        print("✓ Tuner initialized successfully\n")
+    except Exception as e:
+        print(f"✗ Failed to initialize tuner: {e}")
+        return False
+    
+    # Test matrix
+    pipelines = ['faster', 'fast', 'balanced']
+    sensitivities = ['conservative', 'balanced', 'aggressive']
+    tasks = ['transcribe', 'translate']
+    
+    success_count = 0
+    failure_count = 0
+    
+    for pipeline in pipelines:
+        print(f"\n{'-'*40}")
+        print(f"Pipeline: {pipeline.upper()}")
+        print(f"{'-'*40}")
+        
+        for sensitivity in sensitivities:
+            for task in tasks:
+                test_name = f"{pipeline}/{sensitivity}/{task}"
+                try:
+                    # Resolve parameters
+                    result = tuner.resolve_params(pipeline, sensitivity, task)
+                    
+                    # Validate structure
+                    assert 'params' in result, "Missing 'params' in result"
+                    assert 'decoder' in result['params'], "Missing 'decoder' in params"
+                    assert 'provider' in result['params'], "Missing 'provider' in params"
+                    assert 'vad' in result['params'], "Missing 'vad' in params"
+                    
+                    # Validate decoder task override
+                    assert result['params']['decoder'].get('task') == task, \
+                        f"Task override failed: expected {task}, got {result['params']['decoder'].get('task')}"
+                    
+                    # Check VAD handling
+                    if pipeline == 'balanced':
+                        # Should have separate VAD params
+                        if not result['params']['vad']:
+                            print(f"  ⚠ {test_name}: No VAD params (expected for balanced)")
+                    else:
+                        # VAD should be packed into provider for faster/fast
+                        if 'vad' in result['params']['provider'] or 'vad_threshold' in result['params']['provider']:
+                            print(f"  ✓ {test_name}: VAD packed in provider")
+                        else:
+                            print(f"  ✓ {test_name}: No VAD (none specified)")
+                    
+                    print(f"  ✓ {test_name}: SUCCESS")
+                    success_count += 1
+                    
+                except Exception as e:
+                    print(f"  ✗ {test_name}: FAILED - {e}")
+                    failure_count += 1
+    
+    print(f"\n{'='*60}")
+    print(f"RESULTS: {success_count} passed, {failure_count} failed")
+    print(f"{'='*60}")
+    
+    return failure_count == 0
+
+
+def test_specific_configuration(pipeline='faster', sensitivity='balanced', task='transcribe'):
+    """Test and display a specific configuration in detail."""
+    
+    print(f"\n{'='*60}")
+    print(f"Detailed Test: {pipeline}/{sensitivity}/{task}")
+    print(f"{'='*60}\n")
+    
+    tuner = TranscriptionTuner()
+    result = tuner.resolve_params(pipeline, sensitivity, task)
+    
+    print("Structure returned:")
+    print("-" * 40)
+    
+    # Show high-level structure
+    for key in result:
+        if key == 'params':
+            print(f"params:")
+            for param_key in result['params']:
+                param_count = len(result['params'][param_key]) if result['params'][param_key] else 0
+                print(f"  {param_key}: {param_count} parameters")
+        elif isinstance(result[key], dict):
+            print(f"{key}: {len(result[key])} items")
+        else:
+            print(f"{key}: {result[key]}")
+    
+    print("\n" + "-" * 40)
+    print("Key parameters:")
+    print("-" * 40)
+    
+    # Show some key parameters
+    decoder = result['params']['decoder']
+    provider = result['params']['provider']
+    
+    print(f"Decoder:")
+    print(f"  task: {decoder.get('task')}")
+    print(f"  language: {decoder.get('language')}")
+    print(f"  beam_size: {decoder.get('beam_size')}")
+    print(f"  best_of: {decoder.get('best_of')}")
+    
+    print(f"\nProvider:")
+    print(f"  temperature: {provider.get('temperature')}")
+    print(f"  no_speech_threshold: {provider.get('no_speech_threshold')}")
+    
+    # Check for engine-specific params
+    if 'batch_size' in provider:
+        print(f"  batch_size: {provider.get('batch_size')} (faster-whisper specific)")
+    if 'repetition_penalty' in provider:
+        print(f"  repetition_penalty: {provider.get('repetition_penalty')} (faster-whisper specific)")
+    if 'regroup' in provider:
+        print(f"  regroup: {provider.get('regroup')} (stable-ts specific)")
+    if 'vad' in provider:
+        print(f"  vad: {provider.get('vad')} (VAD packed in provider)")
+    
+    if result['params']['vad']:
+        print(f"\nVAD (separate):")
+        print(f"  threshold: {result['params']['vad'].get('threshold')}")
+        print(f"  min_speech_duration_ms: {result['params']['vad'].get('min_speech_duration_ms')}")
+    
+    return result
+
+
+def validate_config_consistency():
+    """Validate that the configuration is internally consistent."""
+    
+    print(f"\n{'='*60}")
+    print("Configuration Consistency Validation")
+    print(f"{'='*60}\n")
+    
+    tuner = TranscriptionTuner()
+    
+    try:
+        result = tuner.validate_configuration()
+        print("✓ Configuration validation PASSED")
+        return True
+    except Exception as e:
+        print(f"✗ Configuration validation FAILED: {e}")
+        return False
+
+
+def main():
+    """Run all tests."""
+    
+    # Test parameter resolution for all combinations
+    if not test_parameter_resolution():
+        sys.exit(1)
+    
+    # Test specific configuration in detail
+    print("\n" + "="*60)
+    print("DETAILED CONFIGURATION EXAMPLES")
+    print("="*60)
+    
+    test_specific_configuration('faster', 'conservative', 'transcribe')
+    test_specific_configuration('balanced', 'aggressive', 'translate')
+    
+    # Validate configuration consistency
+    if not validate_config_consistency():
+        sys.exit(1)
+    
+    print("\n✓ All tests passed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/whisperjav/translate/cli.py
+++ b/whisperjav/translate/cli.py
@@ -359,6 +359,35 @@ def main():
              "Note: batch size and max-tokens are auto-recomputed from this override."
     )
     ollama_group.add_argument(
+        '--ollama-temperature', type=float, default=None,
+        help="Sampling temperature for Ollama (0.0-2.0). Lower = more faithful/"
+             "deterministic, higher = more creative. Overrides the curated default."
+    )
+    ollama_group.add_argument(
+        '--ollama-top-p', type=float, default=None,
+        help="top_p nucleus sampling for Ollama (0.0-1.0). Baked into an optimized "
+             "model variant (PySubtrans only forwards temperature to the API)."
+    )
+    ollama_group.add_argument(
+        '--ollama-top-k', type=int, default=None,
+        help="top_k sampling for Ollama. Baked into an optimized model variant."
+    )
+    ollama_group.add_argument(
+        '--ollama-min-p', type=float, default=None,
+        help="min_p sampling floor for Ollama (0.0-1.0). Baked into an optimized variant."
+    )
+    ollama_group.add_argument(
+        '--ollama-repeat-penalty', type=float, default=None,
+        help="repeat_penalty for Ollama (e.g. 1.1). Higher discourages repetition. "
+             "Baked into an optimized model variant."
+    )
+    ollama_group.add_argument(
+        '--ollama-keep-alive', default=None,
+        help="How long Ollama keeps the model loaded in VRAM between batches "
+             "(e.g. '5m', '30m', '-1' for forever, '0' to unload immediately). "
+             "Keeping it loaded avoids reload stalls between batches."
+    )
+    ollama_group.add_argument(
         '--yes', '-y',
         action='store_true',
         help="Auto-confirm prompts (model downloads, server starts)"
@@ -584,12 +613,26 @@ def main():
         interactive = sys.stdin.isatty() and not getattr(args, 'yes', False)
         auto_pull = getattr(args, 'yes', False)
 
+        # Custom sampling params → baked into an optimized model variant.
+        # PySubtrans forwards ONLY temperature to the API per-request, so
+        # top_p/top_k/min_p/repeat_penalty must be applied server-side via the
+        # variant. None values are ignored (curated default kept).
+        _ollama_sampling = {
+            'temperature': getattr(args, 'ollama_temperature', None),
+            'top_p': getattr(args, 'ollama_top_p', None),
+            'top_k': getattr(args, 'ollama_top_k', None),
+            'min_p': getattr(args, 'ollama_min_p', None),
+            'repeat_penalty': getattr(args, 'ollama_repeat_penalty', None),
+        }
+
         try:
             readiness = mgr.ensure_ready(
                 model=model,
                 auto_start=True,
                 auto_pull=auto_pull,
                 interactive=interactive,
+                sampling=_ollama_sampling,
+                num_ctx_override=getattr(args, 'ollama_num_ctx', None),
             )
         except OllamaNotInstalledError as e:
             print(f"\n{e}", file=sys.stderr)
@@ -601,16 +644,16 @@ def main():
             print(f"\nERROR: {e}", file=sys.stderr)
             sys.exit(1)
 
-        # Dynamic config from model metadata
+        # Dynamic config from model metadata. ensure_ready() has already
+        # applied any --ollama-num-ctx override (num_ctx_override) to both
+        # readiness['num_ctx'] AND the baked model variant, so this value is
+        # the effective context window for batch_size capping / max_tokens.
         model = readiness['model']
         ollama_n_ctx = readiness['num_ctx']
-        # User --ollama-num-ctx override is applied BEFORE batch_size capping
-        # and max_tokens computation, so both downstream values honor the override.
         _user_n_ctx = getattr(args, 'ollama_num_ctx', None)
         if _user_n_ctx is not None:
-            print(f"[OLLAMA] num_ctx overridden by --ollama-num-ctx: "
-                  f"{ollama_n_ctx} -> {_user_n_ctx}", file=sys.stderr)
-            ollama_n_ctx = _user_n_ctx
+            print(f"[OLLAMA] num_ctx overridden by --ollama-num-ctx: {ollama_n_ctx} "
+                  f"(baked into model variant)", file=sys.stderr)
         _user_batch = merged.get('max_batch_size', readiness['batch_size'])
         ollama_batch_size = cap_batch_size_for_context(_user_batch, ollama_n_ctx)
         ollama_max_tokens = compute_max_output_tokens(ollama_batch_size, ollama_n_ctx)
@@ -634,6 +677,20 @@ def main():
         if not _user_set_temp_cli and not _user_set_temp_settings:
             if effective_tone != 'pornify':
                 provider_options['temperature'] = readiness.get('temperature', 0.3)
+
+        # --ollama-temperature is the highest-priority temperature override.
+        # It must go on the request path (provider_options) because PySubtrans
+        # sends temperature per-request, which overrides any Modelfile PARAMETER.
+        _ollama_temp = getattr(args, 'ollama_temperature', None)
+        if _ollama_temp is not None:
+            provider_options['temperature'] = max(0.0, min(2.0, _ollama_temp))
+
+        # keep_alive controls how long Ollama holds the model in VRAM between
+        # batches. PySubtrans forwards extra provider_options into the request
+        # body, and Ollama's OpenAI-compatible endpoint accepts keep_alive.
+        _keep_alive = getattr(args, 'ollama_keep_alive', None)
+        if _keep_alive is not None:
+            provider_options['keep_alive'] = _keep_alive
 
         provider_config = dict(provider_config)
         provider_config['max_tokens'] = ollama_max_tokens
@@ -660,9 +717,28 @@ def main():
                   f"{ollama_batch_size} to fit {ollama_n_ctx}-token context", file=sys.stderr)
         print(f"[OLLAMA] model={model}, num_ctx={ollama_n_ctx}, batch_size={ollama_batch_size}, "
               f"max_tokens={ollama_max_tokens}", file=sys.stderr)
-        print(f"[OLLAMA] Final provider_options: temperature={provider_options.get('temperature')}, "
-              f"top_p={provider_options.get('top_p')}",
+        # Echo the EFFECTIVE tuning so the console shows what actually reaches
+        # Ollama. NOTE: only temperature/max_tokens travel in the per-request
+        # body (visible with --debug as "Request Body"); num_ctx + top_k/top_p/
+        # min_p/repeat_penalty are applied server-side via the baked model
+        # variant (see "Created optimized variant" above / `ollama show <model>`).
+        # keep_alive rides in the request body too.
+        _applied = {
+            'temperature': provider_options.get('temperature'),
+            'top_p (request)': provider_options.get('top_p'),
+            'num_ctx (variant)': ollama_n_ctx,
+            'keep_alive (request)': provider_options.get('keep_alive', 'default'),
+        }
+        for _k in ('ollama_top_k', 'ollama_min_p', 'ollama_repeat_penalty'):
+            _v = getattr(args, _k, None)
+            if _v is not None:
+                _applied[_k.replace('ollama_', '') + ' (variant)'] = _v
+        print(f"[OLLAMA] Effective tuning: "
+              + ", ".join(f"{k}={v}" for k, v in _applied.items()),
               file=sys.stderr)
+        print(f"[OLLAMA] (num_ctx + top_k/top_p/min_p/repeat_penalty are baked into "
+              f"the '{model}' variant, not the per-request body — verify with "
+              f"`ollama show {model}`)", file=sys.stderr)
 
     # Batch translation loop
     success_count = 0

--- a/whisperjav/translate/ollama_manager.py
+++ b/whisperjav/translate/ollama_manager.py
@@ -427,33 +427,45 @@ class OllamaManager:
 
     # ── Optimized Model Variants ─────────────────────────────────────
 
-    def _ensure_optimized_variant(self, model: str) -> str:
+    def _ensure_optimized_variant(self, model: str, sampling: Optional[dict] = None) -> str:
         """Create or reuse an optimized model variant with tuned sampling params.
 
         PySubtrans CustomClient only passes ``temperature`` to the Ollama API.
         Other sampling parameters (top_k, top_p, min_p, repeat_penalty) are
         silently ignored. This method works around that limitation by creating
-        a lightweight Ollama model variant with our recommended defaults baked
-        into the Modelfile as PARAMETER directives.
+        a lightweight Ollama model variant with the requested sampling params
+        baked in as PARAMETER directives.
 
         The variant is a thin metadata layer — no model weight duplication.
         Ollama reuses the same GGUF blobs.
 
         Args:
             model: Original model name (e.g., "huihui_ai/hy-mt1.5-abliterated:latest")
+            sampling: Sampling parameter dict to bake in. Falls back to
+                OLLAMA_SAMPLING_DEFAULTS when not provided. Only non-None values
+                are applied, so callers can pass a partial dict (e.g. just
+                {'repeat_penalty': 1.2}) to override individual params.
 
         Returns:
             Variant model name on success, original model name on failure.
         """
         import hashlib
 
-        if not OLLAMA_SAMPLING_DEFAULTS:
-            return model  # No defaults to apply
+        # Merge requested sampling over the curated defaults, dropping None values
+        # (None = "not set by the user", leave the default in place).
+        params = dict(OLLAMA_SAMPLING_DEFAULTS)
+        if sampling:
+            for k, v in sampling.items():
+                if v is not None:
+                    params[k] = v
+
+        if not params:
+            return model  # No params to apply
 
         # Deterministic variant name: hash of (model + params) ensures:
         #   - Same model + same params → same variant (reuse)
-        #   - Params change in code update → new variant created
-        _key = f"{model}:{json.dumps(OLLAMA_SAMPLING_DEFAULTS, sort_keys=True)}"
+        #   - Params change → new variant created
+        _key = f"{model}:{json.dumps(params, sort_keys=True)}"
         _hash = hashlib.sha256(_key.encode()).hexdigest()[:10]
         variant = f"whisperjav-{_hash}"
 
@@ -462,28 +474,43 @@ class OllamaManager:
             print(f"[OLLAMA] Using optimized variant: {variant}", file=sys.stderr)
             return variant
 
-        # Build Modelfile with optimized sampling parameters
-        lines = [f'FROM {model}']
-        for param, value in OLLAMA_SAMPLING_DEFAULTS.items():
-            lines.append(f'PARAMETER {param} {value}')
-        modelfile = '\n'.join(lines)
+        _params_str = ', '.join(f'{k}={v}' for k, v in params.items())
 
-        # Create variant via /api/create (stream=false → single JSON response)
-        try:
-            self._http_post('/api/create', {
-                'model': variant,
-                'modelfile': modelfile,
-                'stream': False,
-            }, timeout=30)
-            print(f"[OLLAMA] Created optimized variant: {variant}", file=sys.stderr)
-            _params_str = ', '.join(f'{k}={v}' for k, v in OLLAMA_SAMPLING_DEFAULTS.items())
-            print(f"[OLLAMA]   Sampling defaults: {_params_str}", file=sys.stderr)
-            return variant
-        except Exception as e:
-            print(f"[OLLAMA] Could not create optimized variant: {e}", file=sys.stderr)
-            print(f"[OLLAMA]   Continuing with original model (only temperature will be tuned)",
-                  file=sys.stderr)
-            return model
+        # Create variant via /api/create (stream=false → single JSON response).
+        # Modern Ollama (>= 0.x with structured create) rejects the legacy
+        # 'modelfile' string field with HTTP 400 and instead wants structured
+        # 'from' + 'parameters' fields. Try the structured payload first, then
+        # fall back to the legacy 'modelfile' string for older servers.
+        structured_payload = {
+            'model': variant,
+            'from': model,
+            'parameters': params,
+            'stream': False,
+        }
+        lines = [f'FROM {model}']
+        for param, value in params.items():
+            lines.append(f'PARAMETER {param} {value}')
+        legacy_payload = {
+            'model': variant,
+            'modelfile': '\n'.join(lines),
+            'stream': False,
+        }
+
+        last_err = None
+        for payload in (structured_payload, legacy_payload):
+            try:
+                self._http_post('/api/create', payload, timeout=30)
+                print(f"[OLLAMA] Created optimized variant: {variant}", file=sys.stderr)
+                print(f"[OLLAMA]   Sampling params: {_params_str}", file=sys.stderr)
+                return variant
+            except Exception as e:
+                last_err = e
+                continue
+
+        print(f"[OLLAMA] Could not create optimized variant: {last_err}", file=sys.stderr)
+        print(f"[OLLAMA]   Continuing with original model (only temperature will be tuned)",
+              file=sys.stderr)
+        return model
 
     # ── Hardware-Aware Recommendation ─────────────────────────────────
 
@@ -529,8 +556,22 @@ class OllamaManager:
         auto_start: bool = True,
         auto_pull: bool = False,
         interactive: bool = True,
+        sampling: Optional[dict] = None,
+        num_ctx_override: Optional[int] = None,
     ) -> dict:
         """Full orchestration: detect server, start if needed, check model, pull if needed.
+
+        Args:
+            sampling: Optional dict of sampling params (top_k, top_p, min_p,
+                repeat_penalty, temperature) to bake into the optimized model
+                variant, overriding OLLAMA_SAMPLING_DEFAULTS. None values are
+                ignored (the curated default is kept).
+            num_ctx_override: Optional context-window override. When set, it
+                replaces the curated num_ctx in the returned dict AND is baked
+                into the optimized variant as a ``num_ctx`` PARAMETER — the only
+                reliable way to change the context window, since Ollama's
+                OpenAI-compatible /v1/chat/completions endpoint ignores a
+                top-level num_ctx field in the request body.
 
         Returns:
             dict with keys: model, num_ctx, batch_size, temperature, server_started, base_url
@@ -628,6 +669,12 @@ class OllamaManager:
         # Use curated config if available, otherwise use dynamic values
         cfg = OLLAMA_MODEL_CONFIGS.get(model, {})
         num_ctx = cfg.get('num_ctx', min(actual_ctx, 8192))
+        # Honor an explicit context-window override (e.g. from --ollama-num-ctx /
+        # the GUI). It must be resolved BEFORE building the variant so the variant
+        # bakes in the right num_ctx — Ollama's OpenAI endpoint ignores a
+        # top-level num_ctx in the request body, so the variant is the only path.
+        if num_ctx_override is not None:
+            num_ctx = int(num_ctx_override)
         batch_size = cfg.get('batch_size', 11)
         # Default 0.3: best-fit compromise across 10 tested local models for
         # JAV subtitle translation (range 0.2–0.4, median 0.3). Keeps strong
@@ -650,9 +697,13 @@ class OllamaManager:
 
         # Step 6c: Create optimized variant with tuned sampling parameters.
         # PySubtrans only passes temperature to the API — top_k, top_p, min_p,
-        # repeat_penalty are silently dropped. By baking them into a Modelfile
-        # variant, Ollama applies them server-side as defaults.
-        effective_model = self._ensure_optimized_variant(model)
+        # repeat_penalty, AND num_ctx are silently dropped on Ollama's OpenAI
+        # endpoint. By baking them into a model variant, Ollama applies them
+        # server-side as defaults. We always bake num_ctx so the resolved
+        # context window (curated or overridden) actually takes effect.
+        _variant_params = dict(sampling) if sampling else {}
+        _variant_params['num_ctx'] = num_ctx
+        effective_model = self._ensure_optimized_variant(model, sampling=_variant_params)
 
         # Step 7: Return readiness info
         return {

--- a/whisperjav/webview_gui/api.py
+++ b/whisperjav/webview_gui/api.py
@@ -1921,10 +1921,50 @@ class WhisperJAVAPI:
             (60s) for long audio. Segments longer than this are truncated.
           - batch_size_s: dynamic batch size (throughput vs VRAM)
         Defaults mirror modules/sensevoice_asr.py.
+
+        Tab layout mirrors the Transformers modal (Model / Quality / Chunking /
+        Enhancer / Scene). NOTE: in ensemble, the main-tab Model and Scene
+        Detector dropdowns take precedence over the modal's model_id/scene
+        (pass_worker applies pass_config overrides after modal params) — the
+        modal descriptions say so.
         """
         return {
             "success": True,
             "schema": {
+                "model": {
+                    "model_id": {
+                        "type": "dropdown",
+                        "label": "ASR Model",
+                        "options": [
+                            {"value": "iic/SenseVoiceSmall",
+                             "label": "SenseVoice Small (~1GB VRAM)"},
+                        ],
+                        "default": "iic/SenseVoiceSmall",
+                    },
+                    "device": {
+                        "type": "dropdown",
+                        "label": "Device",
+                        "options": [
+                            {"value": "auto", "label": "Auto (detect GPU)"},
+                            {"value": "cuda", "label": "CUDA (GPU)"},
+                            {"value": "cpu", "label": "CPU"},
+                        ],
+                        "default": "auto",
+                    },
+                },
+                "scene": {
+                    "scene": {
+                        "type": "dropdown",
+                        "label": "Scene Detection Method",
+                        "options": [
+                            {"value": "auditok", "label": "Auditok (energy-based)"},
+                            {"value": "silero", "label": "Silero (VAD-based)"},
+                            {"value": "semantic", "label": "Semantic"},
+                            {"value": "none", "label": "None (process whole file)"},
+                        ],
+                        "default": "auditok",
+                    },
+                },
                 "decoding": {
                     "use_itn": {
                         "type": "checkbox",

--- a/whisperjav/webview_gui/api.py
+++ b/whisperjav/webview_gui/api.py
@@ -143,6 +143,10 @@ class WhisperJAVAPI:
         if mode == 'transformers':
             return self._build_transformers_args(args, options)
 
+        # Handle SenseVoice mode separately (uses --sv-* arguments)
+        if mode == 'sensevoice':
+            return self._build_sensevoice_args(args, options)
+
         # Source audio language (for transcription)
         source_language = options.get('source_language', 'japanese')
         args += ["--language", source_language]
@@ -195,6 +199,17 @@ class WhisperJAVAPI:
         speech_segmenter = options.get('speech_segmenter', '').strip()
         if speech_segmenter:
             args += ["--speech-segmenter", speech_segmenter]
+
+        # Batched inference pipeline (issue #357) — balanced pipeline speedup.
+        # Only emit when explicitly set; otherwise the config default (on) applies.
+        batched_pipeline = options.get('batched_pipeline', None)
+        if batched_pipeline is not None:
+            args += ["--batched-pipeline", "true" if batched_pipeline else "false"]
+            # Only forward batch size when batching is enabled.
+            if batched_pipeline:
+                batch_size = options.get('batch_size', None)
+                if batch_size:
+                    args += ["--batch-size", str(int(batch_size))]
 
         # Model override
         model_override = options.get('model_override', '').strip()
@@ -283,6 +298,68 @@ class WhisperJAVAPI:
             args += ["--debug"]
 
         # Output format (srt/vtt/both)
+        output_format = options.get('output_format', 'srt')
+        if output_format and output_format != 'srt':
+            args += ["--output-format", output_format]
+
+        if options.get('accept_cpu_mode', False):
+            args += ["--accept-cpu-mode"]
+
+        return args
+
+    def _build_sensevoice_args(self, args: List[str], options: Dict[str, Any]) -> List[str]:
+        """Build CLI arguments for SenseVoice mode (uses --sv-* arguments).
+
+        SenseVoice does not use the legacy sensitivity/speech-segmenter knobs.
+        Source language is mapped from the GUI's full-name value to a SenseVoice
+        language code.
+        """
+        # Map GUI source-language (full names) to SenseVoice language codes.
+        lang_map = {
+            'japanese': 'ja', 'english': 'en', 'chinese': 'zh',
+            'cantonese': 'yue', 'korean': 'ko', 'auto': 'auto',
+        }
+        source_language = options.get('source_language', 'japanese')
+        args += ["--sv-language", lang_map.get(source_language, 'ja')]
+
+        # Subtitle output language (native / direct-to-english). SenseVoice can't
+        # translate, but the flag is forwarded for consistent output naming.
+        subs_language = options.get('subs_language', 'native')
+        args += ["--subs-language", subs_language]
+
+        output_dir = options.get('output_dir', self.default_output)
+        args += ["--output-dir", output_dir]
+
+        # Scene detection method (subtitle granularity). Default auditok.
+        sv_scene = options.get('sv_scene', '').strip()
+        if sv_scene:
+            args += ["--sv-scene", sv_scene]
+
+        # Optional model id override
+        sv_model_id = options.get('sv_model_id', '').strip()
+        if sv_model_id:
+            args += ["--sv-model-id", sv_model_id]
+
+        # Customize-modal params (use_itn, diarize, merge_vad, ...) forwarded as a
+        # single JSON blob — main.py merges it over the individual --sv-* flags.
+        # This is what makes the single-pass SenseVoice customize modal actually
+        # take effect (previously dropped). Only sent when the user customized.
+        sv_params = options.get('sv_params')
+        if sv_params:
+            import json as _json
+            args += ["--sv-params", _json.dumps(sv_params)]
+
+        # Common options
+        temp_dir = options.get('temp_dir', '').strip()
+        if temp_dir:
+            args += ["--temp-dir", temp_dir]
+
+        if options.get('keep_temp', False):
+            args += ["--keep-temp"]
+
+        if options.get('debug', False):
+            args += ["--debug"]
+
         output_format = options.get('output_format', 'srt')
         if output_format and output_format != 'srt':
             args += ["--output-format", output_format]
@@ -1830,6 +1907,98 @@ class WhisperJAVAPI:
             }
         }
 
+    def get_sensevoice_schema(self) -> Dict[str, Any]:
+        """
+        Get parameter schema for the SenseVoice (FunASR) customize modal.
+
+        SenseVoice is non-autoregressive — it has no Whisper-style decoder
+        params (beam/temperature/logprob). What it does expose:
+          - use_itn: inverse text normalization (punctuation/numbers)
+          - ban_emo_unk: suppress the <|EMO_UNKNOWN|> emotion token
+          - merge_vad / merge_length_s: merge short fsmn-vad segments
+          - vad_max_segment_ms: max single VAD chunk = FunASR
+            vad_kwargs.max_single_segment_time; tutorial recommends 60000ms
+            (60s) for long audio. Segments longer than this are truncated.
+          - batch_size_s: dynamic batch size (throughput vs VRAM)
+        Defaults mirror modules/sensevoice_asr.py.
+        """
+        return {
+            "success": True,
+            "schema": {
+                "decoding": {
+                    "use_itn": {
+                        "type": "checkbox",
+                        "label": "Inverse Text Normalization (punctuation/numbers)",
+                        "default": True,
+                    },
+                    "ban_emo_unk": {
+                        "type": "checkbox",
+                        "label": "Ban unknown-emotion token",
+                        "default": False,
+                    },
+                    "diarize": {
+                        "type": "checkbox",
+                        "label": "Speaker diarization ([spkN] labels)",
+                        "default": False,
+                    },
+                    "spk_num": {
+                        "type": "slider",
+                        "label": "Force speaker count (0 = auto)",
+                        "min": 0, "max": 10, "step": 1, "default": 0,
+                    },
+                },
+                "vad": {
+                    "merge_vad": {
+                        "type": "checkbox",
+                        "label": "Merge short VAD segments",
+                        "default": True,
+                    },
+                    "merge_length_s": {
+                        "type": "slider",
+                        "label": "Merge target length (s)",
+                        "min": 1, "max": 30, "step": 1, "default": 15,
+                    },
+                    "vad_max_segment_ms": {
+                        "type": "slider",
+                        "label": "Max VAD segment (ms)",
+                        "min": 5000, "max": 60000, "step": 1000, "default": 60000,
+                    },
+                    "batch_size_s": {
+                        "type": "slider",
+                        "label": "Batch size (audio-seconds)",
+                        "min": 10, "max": 300, "step": 10, "default": 60,
+                    },
+                },
+                "enhancer": {
+                    "bsrf_overlap": {
+                        "type": "slider",
+                        "label": "BS-RoFormer overlap (speed vs quality)",
+                        "min": 1, "max": 4, "step": 1, "default": 2,
+                    },
+                },
+                # Post-processing filters. The shared sanitizer is tuned for
+                # Whisper and over-removes SenseVoice output; defaults are relaxed
+                # (hallucination + CPS off, repetition on). (#350)
+                "postproc": {
+                    "remove_hallucinations": {
+                        "type": "checkbox",
+                        "label": "Remove hallucinations (Whisper blacklist)",
+                        "default": False,
+                    },
+                    "remove_repetitions": {
+                        "type": "checkbox",
+                        "label": "Clean repetitions",
+                        "default": True,
+                    },
+                    "remove_cps_outliers": {
+                        "type": "checkbox",
+                        "label": "Drop abnormal-speed lines (CPS filter)",
+                        "default": False,
+                    },
+                },
+            },
+        }
+
     def get_qwen_schema(self) -> Dict[str, Any]:
         """
         Get parameter schema for Qwen3-ASR pipeline customize modal.
@@ -2511,6 +2680,11 @@ class WhisperJAVAPI:
             if pass1.get('customized') and pass1.get('params'):
                 args += ["--pass1-hf-params", json.dumps(pass1['params'])]
             # else: minimal args - backend uses model defaults
+        elif pass1.get('isSenseVoice'):
+            # SenseVoice pass: no sensitivity. Forward customize-modal params
+            # (use_itn, merge_vad, merge_length_s, etc.) via --pass1-params.
+            if pass1.get('customized') and pass1.get('params'):
+                args += ["--pass1-params", json.dumps(pass1['params'])]
         elif pass1.get('isQwen'):
             # Qwen pass: sensitivity resolves segmenter config via YAML presets
             if pass1.get('sensitivity'):
@@ -2558,8 +2732,13 @@ class WhisperJAVAPI:
         # - Qwen/Legacy: Use --pass1-speech-segmenter (pass_worker.py translates to qwen_segmenter for Qwen)
         segmenter1 = pass1.get('speechSegmenter')
         if pass1.get('isTransformers'):
-            # Transformers: Skip segmenter entirely (HF internal chunking)
+            # Transformers: HF internal chunking — no external segmenter.
             pass
+        elif pass1.get('isSenseVoice'):
+            # SenseVoice: the segmenter dropdown toggles its internal fsmn-vad.
+            # Pass it through so the worker can disable VAD when "none".
+            if segmenter1:
+                args += ["--pass1-speech-segmenter", segmenter1]
         else:
             # Both Qwen and Legacy use --pass1-speech-segmenter
             # For Qwen: pass_worker.py translates to qwen_segmenter (post-ASR VAD filter)
@@ -2615,6 +2794,10 @@ class WhisperJAVAPI:
                 if pass2.get('customized') and pass2.get('params'):
                     args += ["--pass2-hf-params", json.dumps(pass2['params'])]
                 # else: minimal args - backend uses model defaults
+            elif pass2.get('isSenseVoice'):
+                # SenseVoice pass: no sensitivity. Forward customize-modal params.
+                if pass2.get('customized') and pass2.get('params'):
+                    args += ["--pass2-params", json.dumps(pass2['params'])]
             elif pass2.get('isQwen'):
                 # Qwen pass: sensitivity resolves segmenter config via YAML presets
                 if pass2.get('sensitivity'):
@@ -2658,8 +2841,12 @@ class WhisperJAVAPI:
                 # - Qwen/Legacy: Use --pass2-speech-segmenter (pass_worker.py translates to qwen_segmenter for Qwen)
                 segmenter2 = pass2.get('speechSegmenter')
                 if pass2.get('isTransformers'):
-                    # Transformers: Skip segmenter entirely (HF internal chunking)
+                    # Transformers: HF internal chunking — no external segmenter.
                     pass
+                elif pass2.get('isSenseVoice'):
+                    # SenseVoice: segmenter dropdown toggles its internal fsmn-vad.
+                    if segmenter2:
+                        args += ["--pass2-speech-segmenter", segmenter2]
                 else:
                     # Both Qwen and Legacy use --pass2-speech-segmenter
                     # For Qwen: pass_worker.py translates to qwen_segmenter (post-ASR VAD filter)
@@ -3112,6 +3299,17 @@ class WhisperJAVAPI:
                 'ollamaUrl': backend.get('ollama_url', '') or '',
                 'provider': backend.get('provider', ''),
             }
+            # Ollama tuning knobs (None/missing → '' so the GUI shows a blank =
+            # "use curated default").
+            ot = backend.get('ollama_tuning') or {}
+            gui_settings.update({
+                'ollamaNumCtx': ot.get('num_ctx') if ot.get('num_ctx') is not None else '',
+                'ollamaMaxTokens': ot.get('max_tokens') if ot.get('max_tokens') is not None else '',
+                'ollamaTopK': ot.get('top_k') if ot.get('top_k') is not None else '',
+                'ollamaMinP': ot.get('min_p') if ot.get('min_p') is not None else '',
+                'ollamaRepeatPenalty': ot.get('repeat_penalty') if ot.get('repeat_penalty') is not None else '',
+                'ollamaKeepAlive': ot.get('keep_alive') if ot.get('keep_alive') is not None else '',
+            })
             return {"success": True, "settings": gui_settings}
         except Exception as e:
             return {"success": False, "error": str(e)}
@@ -3159,6 +3357,24 @@ class WhisperJAVAPI:
                 existing['ollama_url'] = settings['ollamaUrl'] or None
             if 'provider' in settings:
                 existing['provider'] = settings['provider']
+
+            # Ollama tuning knobs (stored under a nested dict; '' / None means
+            # "use the curated default"). Kept separate from model_params so they
+            # only ever apply to the Ollama provider path.
+            _ot_map = {
+                'ollamaNumCtx': 'num_ctx',
+                'ollamaMaxTokens': 'max_tokens',
+                'ollamaTopK': 'top_k',
+                'ollamaMinP': 'min_p',
+                'ollamaRepeatPenalty': 'repeat_penalty',
+                'ollamaKeepAlive': 'keep_alive',
+            }
+            if any(k in settings for k in _ot_map):
+                ot = existing.setdefault('ollama_tuning', {})
+                for js_key, be_key in _ot_map.items():
+                    if js_key in settings:
+                        val = settings[js_key]
+                        ot[be_key] = val if (val not in ('', None)) else None
 
             # Nested model_params
             mp = existing.setdefault('model_params', {})
@@ -3659,6 +3875,25 @@ class WhisperJAVAPI:
                 args.extend(["--max-batch-size", str(options['max_batch_size'])])
             if options.get('max_retries'):
                 args.extend(["--max-retries", str(options['max_retries'])])
+            # Ollama tuning knobs (only meaningful for the ollama provider).
+            # Empty/None means "use the curated default" → don't pass the flag.
+            if provider == 'ollama':
+                if options.get('ollama_num_ctx'):
+                    args.extend(["--ollama-num-ctx", str(options['ollama_num_ctx'])])
+                if options.get('ollama_max_tokens'):
+                    args.extend(["--ollama-max-tokens", str(options['ollama_max_tokens'])])
+                if options.get('ollama_temperature') not in (None, ''):
+                    args.extend(["--ollama-temperature", str(options['ollama_temperature'])])
+                if options.get('ollama_top_p') not in (None, ''):
+                    args.extend(["--ollama-top-p", str(options['ollama_top_p'])])
+                if options.get('ollama_top_k') not in (None, ''):
+                    args.extend(["--ollama-top-k", str(options['ollama_top_k'])])
+                if options.get('ollama_min_p') not in (None, ''):
+                    args.extend(["--ollama-min-p", str(options['ollama_min_p'])])
+                if options.get('ollama_repeat_penalty') not in (None, ''):
+                    args.extend(["--ollama-repeat-penalty", str(options['ollama_repeat_penalty'])])
+                if options.get('ollama_keep_alive') not in (None, ''):
+                    args.extend(["--ollama-keep-alive", str(options['ollama_keep_alive'])])
             # Output directory — honor the shared Destination section.
             # 'source' is a sentinel meaning "save next to input file" (default).
             _out_dir = options.get('output_dir', '')

--- a/whisperjav/webview_gui/assets/app.js
+++ b/whisperjav/webview_gui/assets/app.js
@@ -185,6 +185,12 @@ const ModeManager = {
             if (transformersInfoRow) transformersInfoRow.style.display = 'none';
             sensitivityLabel.textContent = 'Sensitivity (accuracy vs false-positives):';
         }
+
+        // Show the single-pass SenseVoice diarization toggle only in sensevoice mode.
+        const svDiarizeRow = document.getElementById('adv-row-sv-diarize');
+        if (svDiarizeRow) {
+            svDiarizeRow.style.display = (mode === 'sensevoice') ? '' : 'none';
+        }
     },
 
     isTransformersMode() {
@@ -287,6 +293,40 @@ const QwenManager = {
         this.customized = true;
     },
 
+    resetToDefaults() {
+        this.params = null;
+        this.customized = false;
+    }
+};
+
+// SenseVoice (FunASR) parameter defaults — mirror modules/sensevoice_asr.py.
+const SenseVoiceManager = {
+    params: null,
+    customized: false,
+    defaults: {
+        use_itn: true,
+        ban_emo_unk: false,
+        merge_vad: true,
+        merge_length_s: 15,
+        vad_max_segment_ms: 60000,
+        batch_size_s: 60,
+        // Post-processing (relaxed for SenseVoice — see api.get_sensevoice_schema)
+        remove_hallucinations: false,
+        remove_repetitions: true,
+        remove_cps_outliers: false,
+        // Speaker diarization (funasr cam++); spk_num 0 = auto-detect count
+        diarize: false,
+        spk_num: 0,
+    },
+    getParams() {
+        return this.customized && this.params
+            ? { ...this.defaults, ...this.params }
+            : { ...this.defaults };
+    },
+    setParams(params) {
+        this.params = params;
+        this.customized = true;
+    },
     resetToDefaults() {
         this.params = null;
         this.customized = false;
@@ -668,6 +708,17 @@ const FormManager = {
             modelSelect.disabled = !modelOverrideCheckbox.checked;
         });
 
+        // Batched transcription toggle (issue #357): grey out batch size when off
+        const batchedCheckbox = document.getElementById('batchedPipeline');
+        const batchSizeInput = document.getElementById('batchSize');
+        if (batchedCheckbox && batchSizeInput) {
+            const syncBatchSize = () => {
+                batchSizeInput.disabled = !batchedCheckbox.checked;
+            };
+            batchedCheckbox.addEventListener('change', syncBatchSize);
+            syncBatchSize();  // initialize on load
+        }
+
         // Validate on form changes
         document.querySelectorAll('input, select').forEach(input => {
             input.addEventListener('change', () => this.validateForm());
@@ -748,7 +799,14 @@ const FormManager = {
         const modelOverrideEnabled = document.getElementById('modelOverrideEnabled').checked;
         const asyncProcessingEnabled = document.getElementById('asyncProcessing').checked;
 
-        return {
+        // Batched transcription (issue #357) — only meaningful for the balanced
+        // pipeline; harmless for other modes (ignored downstream).
+        const batchedEl = document.getElementById('batchedPipeline');
+        const batchedPipeline = batchedEl ? batchedEl.checked : true;
+        const batchSizeEl = document.getElementById('batchSize');
+        const batchSize = batchSizeEl ? parseInt(batchSizeEl.value, 10) || 8 : 8;
+
+        const legacyOptions = {
             ...baseOptions,
             sensitivity: document.getElementById('sensitivity').value,
 
@@ -760,7 +818,27 @@ const FormManager = {
             // Async processing (conditional)
             async_processing: asyncProcessingEnabled,
 
+            // Batched transcription speedup
+            batched_pipeline: batchedPipeline,
+            batch_size: batchSize,
+
         };
+
+        // Single-pass SenseVoice: forward the Advanced-Options diarization toggle
+        // as sv_params (api._build_sensevoice_args → --sv-params → main.py).
+        // Previously single-pass SenseVoice dropped all customize params.
+        if (mode === 'sensevoice') {
+            const svDiarizeEl = document.getElementById('svDiarize');
+            if (svDiarizeEl && svDiarizeEl.checked) {
+                const svParams = { diarize: true };
+                const spkNumEl = document.getElementById('svSpkNum');
+                const spkNum = spkNumEl ? parseInt(spkNumEl.value, 10) : 0;
+                if (spkNum && spkNum > 0) svParams.spk_num = spkNum;
+                legacyOptions.sv_params = svParams;
+            }
+        }
+
+        return legacyOptions;
     }
 };
 
@@ -1225,6 +1303,7 @@ const EnsembleManager = {
             isQwen: false,  // ChronosJAV umbrella: any of qwen / anime-whisper / cohere
             isAnimeWhisper: false,  // Track if using Anime-Whisper specifically
             isCohere: false,  // Track if using Cohere-Transcribe specifically (v1.8.14)
+            isSenseVoice: false,  // Track if using SenseVoice (FunASR, issue #350)
             framer: 'vad-grouped',  // Qwen temporal framer (vad-grouped/full-scene)
             dspEffects: ['loudnorm'],  // Default FFmpeg DSP effects
             enhanceForVad: false  // Dual-track: use enhanced audio for VAD only, original for ASR
@@ -1244,6 +1323,7 @@ const EnsembleManager = {
             isQwen: true,  // Default pipeline is Qwen3-ASR (ChronosJAV umbrella)
             isAnimeWhisper: false,
             isCohere: false,  // v1.8.14: Cohere-Transcribe preview (gated HF model)
+            isSenseVoice: false,  // Track if using SenseVoice (FunASR, issue #350)
             isXxl: false,  // Track if using BYOP Faster Whisper XXL
             framer: 'vad-grouped',  // Qwen temporal framer (vad-grouped/full-scene)
             dspEffects: ['loudnorm'],  // Default FFmpeg DSP effects
@@ -1273,6 +1353,9 @@ const EnsembleManager = {
     qwenModels: [
         { value: 'Qwen/Qwen3-ASR-1.7B', label: 'Qwen3-ASR-1.7B    8GB' },
         { value: 'Qwen/Qwen3-ASR-0.6B', label: 'Qwen3-ASR-0.6B    4GB' }
+    ],
+    sensevoiceModels: [
+        { value: 'iic/SenseVoiceSmall', label: 'SenseVoice Small    ~1GB' }
     ],
     animeWhisperModels: [
         { value: 'litagin/anime-whisper', label: 'anime-whisper    ~4GB' },
@@ -1319,10 +1402,12 @@ const EnsembleManager = {
         this.state.pass1.isQwen = (this.state.pass1.pipeline === 'qwen' || this.state.pass1.pipeline === 'anime-whisper' || this.state.pass1.pipeline === 'cohere');
         this.state.pass1.isAnimeWhisper = this.state.pass1.pipeline === 'anime-whisper';
         this.state.pass1.isCohere = this.state.pass1.pipeline === 'cohere';
+        this.state.pass1.isSenseVoice = this.state.pass1.pipeline === 'sensevoice';
         this.state.pass2.isTransformers = this.state.pass2.pipeline === 'transformers';
         this.state.pass2.isQwen = (this.state.pass2.pipeline === 'qwen' || this.state.pass2.pipeline === 'anime-whisper' || this.state.pass2.pipeline === 'cohere');
         this.state.pass2.isAnimeWhisper = this.state.pass2.pipeline === 'anime-whisper';
         this.state.pass2.isCohere = this.state.pass2.pipeline === 'cohere';
+        this.state.pass2.isSenseVoice = this.state.pass2.pipeline === 'sensevoice';
         this.state.pass2.isXxl = this.state.pass2.pipeline === 'xxl';
 
         // Load persisted BYOP preferences (XXL exe path, extra args)
@@ -1354,6 +1439,10 @@ const EnsembleManager = {
             this.swapModelOptions('pass1', 'cohere');
         } else if (this.state.pass1.isQwen) {
             this.swapModelOptions('pass1', 'qwen');
+        } else if (this.state.pass1.isTransformers) {
+            this.swapModelOptions('pass1', 'transformers');
+        } else if (this.state.pass1.isSenseVoice) {
+            this.swapModelOptions('pass1', 'sensevoice');
         }
         if (this.state.pass2.isAnimeWhisper) {
             this.swapModelOptions('pass2', 'anime-whisper');
@@ -1361,6 +1450,10 @@ const EnsembleManager = {
             this.swapModelOptions('pass2', 'cohere');
         } else if (this.state.pass2.isQwen) {
             this.swapModelOptions('pass2', 'qwen');
+        } else if (this.state.pass2.isTransformers) {
+            this.swapModelOptions('pass2', 'transformers');
+        } else if (this.state.pass2.isSenseVoice) {
+            this.swapModelOptions('pass2', 'sensevoice');
         }
 
         // Pass 2 enable/disable
@@ -1519,18 +1612,20 @@ const EnsembleManager = {
         const isQwen = (newValue === 'qwen' || newValue === 'anime-whisper' || newValue === 'cohere');
         const isAnimeWhisper = newValue === 'anime-whisper';
         const isCohere = newValue === 'cohere';
+        const isSenseVoice = newValue === 'sensevoice';
         const isXxl = newValue === 'xxl';
         const wasTransformers = passState.isTransformers;
         const wasQwen = passState.isQwen;
         const wasAnimeWhisper = passState.isAnimeWhisper;
         const wasCohere = passState.isCohere;
+        const wasSenseVoice = passState.isSenseVoice;
 
         // Determine pipeline category for model swapping. Specific ChronosJAV
         // backends (anime-whisper, cohere) take precedence over the qwen umbrella.
-        const getPipelineType = (isT, isQ, isAW, isC) =>
-            isT ? 'transformers' : (isAW ? 'anime-whisper' : (isC ? 'cohere' : (isQ ? 'qwen' : 'legacy')));
-        const oldType = getPipelineType(wasTransformers, wasQwen, wasAnimeWhisper, wasCohere);
-        const newType = getPipelineType(isTransformers, isQwen, isAnimeWhisper, isCohere);
+        const getPipelineType = (isT, isQ, isAW, isC, isSV) =>
+            isT ? 'transformers' : (isAW ? 'anime-whisper' : (isC ? 'cohere' : (isSV ? 'sensevoice' : (isQ ? 'qwen' : 'legacy'))));
+        const oldType = getPipelineType(wasTransformers, wasQwen, wasAnimeWhisper, wasCohere, wasSenseVoice);
+        const newType = getPipelineType(isTransformers, isQwen, isAnimeWhisper, isCohere, isSenseVoice);
 
         if (passState.customized) {
             // Warn user that custom params will be reset
@@ -1543,6 +1638,7 @@ const EnsembleManager = {
                 passState.isQwen = isQwen;
                 passState.isAnimeWhisper = isAnimeWhisper;
                 passState.isCohere = isCohere;
+                passState.isSenseVoice = isSenseVoice;
                 passState.isXxl = isXxl;
                 this.updateBadges();
                 this.updateRowGreyingState(passKey);
@@ -1562,6 +1658,7 @@ const EnsembleManager = {
             passState.isQwen = isQwen;
             passState.isAnimeWhisper = isAnimeWhisper;
             passState.isCohere = isCohere;
+            passState.isSenseVoice = isSenseVoice;
             passState.isXxl = isXxl;
             this.updateRowGreyingState(passKey);
             this.updateByopPanel();
@@ -1609,6 +1706,19 @@ const EnsembleManager = {
             this.state[passKey].speechSegmenter = 'whisperseg';
             this.state[passKey].sensitivity = 'balanced';
             this.state[passKey].framer = 'vad-grouped';
+        } else if (pipelineType === 'sensevoice') {
+            // SenseVoice: scene detection drives subtitle granularity; the
+            // segmenter dropdown is repurposed as an fsmn-vad on/off toggle and
+            // defaults to fsmn-vad (enabled). Sensitivity is unused.
+            sceneSelect.value = 'auditok';
+            this.state[passKey].sceneDetector = 'auditok';
+            // Default the internal VAD to ON (fsmn-vad). The actual dropdown
+            // options are swapped in by updateRowGreyingState's SenseVoice branch.
+            this.state[passKey].speechSegmenter = 'fsmn-vad';
+            if (sensitivitySelect.querySelector('option[value="none"]')) {
+                sensitivitySelect.value = 'none';
+            }
+            this.state[passKey].sensitivity = 'none';
         } else {
             // Whisper-based pipeline defaults (balanced, faster, fast, fidelity)
             const pipeline = this.state[passKey].pipeline;
@@ -1649,6 +1759,9 @@ const EnsembleManager = {
                 break;
             case 'qwen':
                 models = this.qwenModels;
+                break;
+            case 'sensevoice':
+                models = this.sensevoiceModels;
                 break;
             default:
                 models = this.legacyModels;
@@ -1717,16 +1830,20 @@ const EnsembleManager = {
         if (modelSelect) { modelSelect.disabled = isPass2Disabled; modelSelect.title = ''; }
         if (customizeBtn) { customizeBtn.disabled = isPass2Disabled; customizeBtn.title = ''; }
 
-        // Sensitivity: Disabled only for Transformers (Qwen now uses sensitivity presets)
-        const disableSensitivity = passState.isTransformers;
+        // Sensitivity: Disabled for Transformers and SenseVoice (no sensitivity presets)
+        const disableSensitivity = passState.isTransformers || passState.isSenseVoice;
 
-        // Segmenter: Only disabled for Transformers (uses HF internal chunking)
+        // Segmenter: Disabled for Transformers (HF internal chunking).
+        // SenseVoice repurposes it as an fsmn-vad on/off toggle (handled below),
+        // so it is NOT in the blanket-disable set.
         // Qwen DOES use segmenter as a post-ASR VAD filter (--qwen-segmenter)
         const disableSegmenter = passState.isTransformers;
 
         if (disableSensitivity) {
             sensitivitySelect.disabled = true;
-            sensitivitySelect.title = 'Sensitivity not applicable for Transformers mode';
+            sensitivitySelect.title = passState.isSenseVoice
+                ? 'Sensitivity not applicable for SenseVoice mode'
+                : 'Sensitivity not applicable for Transformers mode';
 
             // Set sensitivity to 'none' for visual clarity (if option exists)
             if (sensitivitySelect.querySelector('option[value="none"]')) {
@@ -1743,17 +1860,30 @@ const EnsembleManager = {
         }
 
         if (disableSegmenter) {
+            // Transformers: restore the standard Whisper segmenter options (in
+            // case we're switching back from SenseVoice) then disable.
+            this.restoreWhisperSegmenterOptions(segmenterSelect);
             segmenterSelect.disabled = true;
             segmenterSelect.title = 'Transformers uses HF internal chunking';
-
-            // Set segmenter to 'none' for visual clarity (if option exists)
             if (segmenterSelect.querySelector('option[value="none"]')) {
                 segmenterSelect.value = 'none';
                 passState.speechSegmenter = 'none';
             }
+        } else if (passState.isSenseVoice) {
+            // SenseVoice: repurpose the dropdown as an fsmn-vad on/off toggle.
+            this.setSenseVoiceSegmenterOptions(segmenterSelect);
+            segmenterSelect.disabled = isPass2Disabled;
+            segmenterSelect.title = 'SenseVoice internal VAD: fsmn-vad (default) or None to disable chunking';
+            // Default to fsmn-vad unless the user already chose none.
+            if (passState.speechSegmenter !== 'none') {
+                segmenterSelect.value = 'fsmn-vad';
+                passState.speechSegmenter = 'fsmn-vad';
+            } else {
+                segmenterSelect.value = 'none';
+            }
         } else {
-            // Re-enable segmenter (unless pass2 is disabled)
-            // Note: Qwen uses segmenter as post-ASR VAD filter
+            // Whisper/Qwen: restore standard segmenter options, then enable.
+            this.restoreWhisperSegmenterOptions(segmenterSelect);
             segmenterSelect.disabled = isPass2Disabled;
             segmenterSelect.title = passState.isQwen ? `Post-ASR VAD filter for ${passState.isAnimeWhisper ? 'Anime-Whisper' : (passState.isCohere ? 'Cohere-Transcribe' : 'Qwen3-ASR')}` : '';
         }
@@ -1761,6 +1891,32 @@ const EnsembleManager = {
         // Parameter guide button: visible only for Qwen pipelines
         const guideBtn = document.getElementById(`guide-${passKey}`);
         if (guideBtn) guideBtn.style.display = passState.isQwen ? '' : 'none';
+    },
+
+    // Replace the segmenter dropdown's options with the SenseVoice VAD toggle
+    // (fsmn-vad / none). The original Whisper options are stashed once so they
+    // can be restored when switching to a Whisper/Qwen pipeline.
+    setSenseVoiceSegmenterOptions(segmenterSelect) {
+        if (!segmenterSelect) return;
+        if (segmenterSelect.dataset.svActive === '1') return;  // already swapped
+        if (!segmenterSelect.dataset.whisperOptions) {
+            segmenterSelect.dataset.whisperOptions = segmenterSelect.innerHTML;
+        }
+        segmenterSelect.innerHTML =
+            '<option value="fsmn-vad" title="FunASR fsmn-vad — chunks long audio internally (default)">fsmn-vad (default)</option>' +
+            '<option value="none" title="Disable SenseVoice internal VAD — each scene is decoded as one un-chunked clip">None (disable VAD)</option>';
+        segmenterSelect.dataset.svActive = '1';
+    },
+
+    // Restore the original Whisper/Qwen segmenter options if they were swapped
+    // out for the SenseVoice VAD toggle.
+    restoreWhisperSegmenterOptions(segmenterSelect) {
+        if (!segmenterSelect) return;
+        if (segmenterSelect.dataset.svActive !== '1') return;  // not swapped
+        if (segmenterSelect.dataset.whisperOptions) {
+            segmenterSelect.innerHTML = segmenterSelect.dataset.whisperOptions;
+        }
+        segmenterSelect.dataset.svActive = '0';
     },
 
     handleSensitivityChange(passKey, newValue, selectElement) {
@@ -2033,6 +2189,10 @@ const EnsembleManager = {
         }
         if (passState.isQwen) {
             await this.openQwenCustomize(passKey);
+            return;
+        }
+        if (passState.isSenseVoice) {
+            await this.openSenseVoiceCustomize(passKey);
             return;
         }
 
@@ -2870,6 +3030,218 @@ const EnsembleManager = {
     },
 
     // ========== Transformers Pipeline Customization ==========
+
+    // --- SenseVoice customize modal (issue #350) ---
+    async openSenseVoiceCustomize(passKey) {
+        this.state.currentCustomize = passKey;
+        const passState = this.state[passKey];
+        try {
+            const result = await pywebview.api.get_sensevoice_schema();
+            if (!result.success) {
+                ErrorHandler.show('Error', 'Failed to load SenseVoice parameters: ' + (result.error || 'Unknown error'));
+                return;
+            }
+            const passLabel = passKey === 'pass1' ? 'Pass 1' : 'Pass 2';
+            const customStatus = passState.customized ? ' [Custom]' : ' [Default]';
+            document.getElementById('customizeModalTitle').textContent =
+                `${passLabel} Settings (SenseVoice / FunASR)${customStatus}`;
+
+            this._sensevoiceSchema = result.schema;
+            const currentValues = passState.customized && passState.params
+                ? { ...SenseVoiceManager.defaults, ...passState.params }
+                : { ...SenseVoiceManager.defaults };
+
+            this.generateSenseVoiceForm(result.schema, currentValues);
+            await this.refreshPresetList();
+            document.getElementById('customizeModal').classList.add('active');
+        } catch (error) {
+            ErrorHandler.show('Error', 'Failed to open SenseVoice customize dialog: ' + error);
+        }
+    },
+
+    generateSenseVoiceForm(schema, currentValues) {
+        // Use two existing tab slots: 'quality' -> Decoding, 'segmenter' -> VAD.
+        // Hide all the other tabs (model/enhancer/scene/context).
+        const tabMap = { quality: 'Decoding', segmenter: 'VAD' };
+        ['model', 'quality', 'segmenter', 'enhancer', 'scene', 'context'].forEach(tab => {
+            const panel = document.getElementById(`tab-${tab}`);
+            if (panel) panel.innerHTML = '';
+            const btn = document.querySelector(`[data-tab="${tab}"]`);
+            if (btn) {
+                if (tabMap[tab]) { btn.style.display = ''; btn.textContent = tabMap[tab]; }
+                else { btn.style.display = 'none'; }
+            }
+        });
+
+        const decoding = document.getElementById('tab-quality');
+        const sec1 = schema.decoding || {};
+        decoding.appendChild(this.createParamCheckbox('use_itn', sec1.use_itn.label,
+            currentValues.use_itn, 'Restore punctuation and number formatting (recommended on)'));
+        decoding.appendChild(this.createParamCheckbox('ban_emo_unk', sec1.ban_emo_unk.label,
+            currentValues.ban_emo_unk, 'Suppress the unknown-emotion token in output'));
+        if (sec1.diarize) {
+            decoding.appendChild(this.createParamCheckbox('diarize', sec1.diarize.label,
+                currentValues.diarize,
+                'Speaker diarization (FunASR cam++): per-sentence [spkN] labels. Runs SenseVoice on the full audio (scene detection auto-disabled) so speaker ids stay consistent; downloads the cam++ model on first use.'));
+            if (sec1.spk_num) {
+                const sn = sec1.spk_num;
+                decoding.appendChild(this.createTransformersSlider('spk_num', sn.label,
+                    sn.min, sn.max, sn.step, currentValues.spk_num ?? sn.default,
+                    'Force a fixed speaker count. 0 = auto-detect (cam++ often collapses to 1 on breathy/monologue audio). Set 2+ when you know the scene’s speaker count.'));
+                const snCtrl = decoding.querySelector('.param-control[data-param="spk_num"]');
+                if (snCtrl) snCtrl.dataset.originalType = 'int';
+            }
+        }
+
+        // Post-processing filters. The shared sanitizer is Whisper-tuned and
+        // over-removes SenseVoice lines; these default OFF/relaxed. (#350)
+        const sec3 = schema.postproc || {};
+        if (sec3.remove_hallucinations) {
+            decoding.appendChild(this.createParamCheckbox('remove_hallucinations',
+                sec3.remove_hallucinations.label, currentValues.remove_hallucinations,
+                'Apply the Whisper hallucination blacklist. OFF by default — SenseVoice’s short utterances collide with Whisper-tuned phrases and get dropped.'));
+            decoding.appendChild(this.createParamCheckbox('remove_repetitions',
+                sec3.remove_repetitions.label, currentValues.remove_repetitions,
+                'Collapse repeated phrases within a line.'));
+            decoding.appendChild(this.createParamCheckbox('remove_cps_outliers',
+                sec3.remove_cps_outliers.label, currentValues.remove_cps_outliers,
+                'Drop lines that are abnormally fast/slow. OFF by default — SenseVoice spans an utterance across the whole scene, so genuine short lines look “too slow” and would be removed.'));
+        }
+
+        const vad = document.getElementById('tab-segmenter');
+        const sec2 = schema.vad || {};
+        vad.appendChild(this.createParamCheckbox('merge_vad', sec2.merge_vad.label,
+            currentValues.merge_vad,
+            'FunASR merge_vad: glue adjacent short fsmn-vad segments together (up to the merge target length) before decoding. Fewer, longer chunks = better context, slightly fewer subtitle lines.'));
+        const ml = sec2.merge_length_s;
+        vad.appendChild(this.createTransformersSlider('merge_length_s', ml.label,
+            ml.min, ml.max, ml.step, currentValues.merge_length_s ?? ml.default,
+            'FunASR merge_length_s: target length (seconds) when merging short VAD segments. Only applies when "Merge short VAD segments" is on.'));
+        const ms = sec2.vad_max_segment_ms;
+        vad.appendChild(this.createTransformersSlider('vad_max_segment_ms', ms.label,
+            ms.min, ms.max, ms.step, currentValues.vad_max_segment_ms ?? ms.default,
+            'FunASR vad_kwargs.max_single_segment_time: longest single VAD chunk (ms). The tutorial recommends 60000 (60s) for long audio. Segments longer than this are TRUNCATED, so keep it at/above your longest expected utterance.'));
+        const bs = sec2.batch_size_s;
+        vad.appendChild(this.createTransformersSlider('batch_size_s', bs.label,
+            bs.min, bs.max, bs.step, currentValues.batch_size_s ?? bs.default,
+            'FunASR batch_size_s: total audio-seconds decoded per dynamic batch. Higher = faster throughput but more VRAM. Independent of subtitle timing.'));
+
+        // BS-RoFormer overlap (only meaningful when the BS-RoFormer enhancer is
+        // selected for this pass). Gated behind an enable checkbox so that when
+        // no speech enhancement is used we don't emit a floating bsrf_overlap
+        // into --passN-params. The gating checkbox is consumed locally and is
+        // NOT collected as a param (see applyCustomization's data-gating-toggle
+        // handling); the slider is skipped entirely when the box is unchecked.
+        const enhSec = schema.enhancer || {};
+        if (enhSec.bsrf_overlap) {
+            const ov = enhSec.bsrf_overlap;
+            // Override is "on" only if a non-default value was previously saved.
+            const overlapEnabled = currentValues.bsrf_overlap != null;
+            const gate = this.createParamGateToggle('enable_bsrf_overlap',
+                'Override BS-RoFormer overlap', overlapEnabled,
+                'Only applies when this pass uses the BS-RoFormer speech enhancer. Leave off to use its default overlap (2).');
+            vad.appendChild(gate);
+            vad.appendChild(this.createTransformersSlider('bsrf_overlap', ov.label,
+                ov.min, ov.max, ov.step, currentValues.bsrf_overlap ?? ov.default,
+                'BS-RoFormer chunk overlap — lower = faster separation, slight quality cost (only used when Speech Enhancer = BS-RoFormer)'));
+            // Tie the slider control to the gate so the collector skips it when off.
+            const ovCtrl = vad.querySelector('.param-control[data-param="bsrf_overlap"]');
+            if (ovCtrl) {
+                ovCtrl.dataset.gatedBy = 'enable_bsrf_overlap';
+                ovCtrl.style.opacity = overlapEnabled ? '1' : '0.5';
+            }
+            // Wire the gate checkbox to enable/disable the slider live.
+            const gateCb = gate.querySelector('.gate-checkbox');
+            if (gateCb && ovCtrl) {
+                const sync = () => {
+                    const on = gateCb.checked;
+                    ovCtrl.style.opacity = on ? '1' : '0.5';
+                    ovCtrl.querySelectorAll('input').forEach(el => { el.disabled = !on; });
+                };
+                gateCb.addEventListener('change', sync);
+                sync();
+            }
+        }
+
+        // Mark integer sliders so applyCustomization parses them as ints.
+        ['merge_length_s', 'vad_max_segment_ms', 'batch_size_s', 'bsrf_overlap'].forEach(p => {
+            const ctrl = document.querySelector(`#tab-segmenter .param-control[data-param="${p}"]`);
+            if (ctrl) ctrl.dataset.originalType = 'int';
+        });
+
+        this.switchModalTab('quality');
+    },
+
+    // Generic checkbox control (no Transformers-specific helper exists).
+    createParamCheckbox(paramName, label, currentValue, description) {
+        const control = document.createElement('div');
+        control.className = 'param-control';
+        control.dataset.param = paramName;
+        control.dataset.originalType = 'bool';
+
+        const wrap = document.createElement('label');
+        wrap.style.display = 'flex';
+        wrap.style.alignItems = 'center';
+        wrap.style.gap = '0.5rem';
+
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'param-checkbox';
+        cb.id = `sv-${paramName}`;
+        cb.checked = !!currentValue;
+
+        const span = document.createElement('span');
+        span.textContent = label;
+
+        wrap.appendChild(cb);
+        wrap.appendChild(span);
+        control.appendChild(wrap);
+
+        if (description) {
+            const desc = document.createElement('p');
+            desc.className = 'param-description';
+            desc.textContent = description;
+            control.appendChild(desc);
+        }
+        return control;
+    },
+
+    // Gate toggle: an enable checkbox that controls whether a sibling param is
+    // collected. Uses classes 'param-gate'/'gate-checkbox' (NOT param-control/
+    // param-checkbox) so the generic applyCustomization collector never harvests
+    // it as a parameter — it only consults gateCb.checked to decide whether to
+    // skip controls marked data-gated-by="<paramName>".
+    createParamGateToggle(paramName, label, currentValue, description) {
+        const gate = document.createElement('div');
+        gate.className = 'param-gate';
+        gate.dataset.gate = paramName;
+
+        const wrap = document.createElement('label');
+        wrap.style.display = 'flex';
+        wrap.style.alignItems = 'center';
+        wrap.style.gap = '0.5rem';
+
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'gate-checkbox';
+        cb.id = `gate-${paramName}`;
+        cb.checked = !!currentValue;
+
+        const span = document.createElement('span');
+        span.textContent = label;
+
+        wrap.appendChild(cb);
+        wrap.appendChild(span);
+        gate.appendChild(wrap);
+
+        if (description) {
+            const desc = document.createElement('p');
+            desc.className = 'param-description';
+            desc.textContent = description;
+            gate.appendChild(desc);
+        }
+        return gate;
+    },
 
     async openTransformersCustomize(passKey) {
         this.state.currentCustomize = passKey;
@@ -4222,6 +4594,17 @@ const EnsembleManager = {
                 const originalType = control.dataset.originalType;
                 let value;
 
+                // Gated controls (e.g. bsrf_overlap) are only collected when
+                // their gating checkbox is checked. When off, skip entirely so
+                // the param never reaches --passN-params — avoids emitting a
+                // floating value (like overlap) that has no effect unless the
+                // BS-RoFormer enhancer is selected.
+                const gatedBy = control.dataset.gatedBy;
+                if (gatedBy) {
+                    const gateCb = panel.querySelector(`.param-gate[data-gate="${gatedBy}"] .gate-checkbox`);
+                    if (gateCb && !gateCb.checked) return;
+                }
+
                 // Find the input element
                 const checkbox = control.querySelector('.param-checkbox');
                 const slider = control.querySelector('.param-slider');
@@ -4835,6 +5218,13 @@ const EnsembleManager = {
             panel.querySelectorAll('.param-control').forEach(control => {
                 const paramName = control.dataset.param;
                 if (!paramName) return;
+                // Skip gated controls (e.g. bsrf_overlap) when their gate is off,
+                // so presets don't bake in a floating overlap value.
+                const gatedBy = control.dataset.gatedBy;
+                if (gatedBy) {
+                    const gateCb = panel.querySelector(`.param-gate[data-gate="${gatedBy}"] .gate-checkbox`);
+                    if (gateCb && !gateCb.checked) return;
+                }
                 const checkbox = control.querySelector('.param-checkbox');
                 const slider = control.querySelector('.param-slider');
                 const number = control.querySelector('.param-number');
@@ -4864,6 +5254,7 @@ const EnsembleManager = {
             isQwen: passState.isQwen,
             isAnimeWhisper: passState.isAnimeWhisper || false,
             isCohere: passState.isCohere || false,
+            isSenseVoice: passState.isSenseVoice || false,
             framer: passState.isQwen ? (passState.framer || 'vad-grouped') : null,
             dspEffects: passState.dspEffects || null,
             enhanceForVad: passState.enhanceForVad || false,
@@ -4934,14 +5325,15 @@ const EnsembleManager = {
             // Detect pipeline type change.
             // getPipelineType signature mirrors handlePipelineChange's local helper —
             // 4-arg form (isT, isQ, isAW, isC) so cohere preset round-trips correctly.
-            const getPipelineType = (isT, isQ, isAW, isC) =>
-                isT ? 'transformers' : (isAW ? 'anime-whisper' : (isC ? 'cohere' : (isQ ? 'qwen' : 'legacy')));
-            const oldType = getPipelineType(passState.isTransformers, passState.isQwen, passState.isAnimeWhisper, passState.isCohere);
+            const getPipelineType = (isT, isQ, isAW, isC, isSV) =>
+                isT ? 'transformers' : (isAW ? 'anime-whisper' : (isC ? 'cohere' : (isSV ? 'sensevoice' : (isQ ? 'qwen' : 'legacy'))));
+            const oldType = getPipelineType(passState.isTransformers, passState.isQwen, passState.isAnimeWhisper, passState.isCohere, passState.isSenseVoice);
             const presetIsTransformers = !!preset.isTransformers;
             const presetIsQwen = !!preset.isQwen;
             const presetIsAnimeWhisper = !!preset.isAnimeWhisper;
             const presetIsCohere = !!preset.isCohere;
-            const newType = getPipelineType(presetIsTransformers, presetIsQwen, presetIsAnimeWhisper, presetIsCohere);
+            const presetIsSenseVoice = !!preset.isSenseVoice;
+            const newType = getPipelineType(presetIsTransformers, presetIsQwen, presetIsAnimeWhisper, presetIsCohere, presetIsSenseVoice);
 
             // Apply ALL preset fields to state
             if (preset.pipeline) passState.pipeline = preset.pipeline;
@@ -4957,6 +5349,7 @@ const EnsembleManager = {
             passState.isQwen = presetIsQwen;
             passState.isAnimeWhisper = presetIsAnimeWhisper;
             passState.isCohere = presetIsCohere;
+            passState.isSenseVoice = presetIsSenseVoice;
             passState.customized = true;
             passState.params = preset.params || null;
             passState.presetName = name;
@@ -5057,8 +5450,8 @@ const EnsembleManager = {
         // Helpers for pipeline-specific null handling:
         // - Sensitivity: null only for Transformers (Qwen now uses sensitivity presets)
         // - Segmenter: null for Transformers only (Qwen uses segmenter as post-ASR VAD filter)
-        const disableSensitivity = (passState) => passState.isTransformers;
-        const disableSegmenter = (passState) => passState.isTransformers;  // NOT Qwen!
+        const disableSensitivity = (passState) => passState.isTransformers || passState.isSenseVoice;
+        const disableSegmenter = (passState) => passState.isTransformers || passState.isSenseVoice;  // NOT Qwen!
 
         const config = {
             inputs: AppState.selectedFiles,
@@ -5077,6 +5470,7 @@ const EnsembleManager = {
                 isQwen: this.state.pass1.isQwen,
                 isAnimeWhisper: this.state.pass1.isAnimeWhisper,
                 isCohere: this.state.pass1.isCohere || false,
+                isSenseVoice: this.state.pass1.isSenseVoice || false,
                 framer: this.state.pass1.isQwen ? this.state.pass1.framer : null,
                 enhanceForVad: this.state.pass1.enhanceForVad || false
             },
@@ -5095,6 +5489,7 @@ const EnsembleManager = {
                 isQwen: this.state.pass2.isQwen,
                 isAnimeWhisper: this.state.pass2.isAnimeWhisper,
                 isCohere: this.state.pass2.isCohere || false,
+                isSenseVoice: this.state.pass2.isSenseVoice || false,
                 isXxl: this.state.pass2.isXxl,
                 framer: this.state.pass2.isQwen ? this.state.pass2.framer : null,
                 enhanceForVad: this.state.pass2.enhanceForVad || false,
@@ -6478,6 +6873,13 @@ const ProviderUIManager = {
             if (modelOverrideEl) modelOverrideEl.style.display = '';
             this.updateModelDropdown(provider, tabContext);
         }
+
+        // Ollama tuning knobs live in the SRT translator tab's Advanced
+        // Settings. Show them only for the Ollama provider on that tab.
+        if (tabContext === 'srt') {
+            const tuning = document.getElementById('translatorOllamaTuning');
+            if (tuning) tuning.style.display = (provider === 'ollama') ? '' : 'none';
+        }
     },
 
     // Track previous dropdown value for revert on cancel
@@ -6755,12 +7157,13 @@ const TranslatorManager = {
     // ---- Translation options & execution ----
 
     collectOptions() {
-        return {
+        const provider = document.getElementById('translatorProvider')?.value || 'deepseek';
+        const options = {
             // Uses shared file list from SOURCE section (AppState.selectedFiles)
             inputs: AppState.selectedFiles,
             // Shared Destination section — same as transcription/ensemble tabs
             output_dir: document.getElementById('outputDir')?.value || '',
-            provider: document.getElementById('translatorProvider')?.value || 'deepseek',
+            provider: provider,
             model: document.getElementById('translatorCustomModel')?.value ||
                    document.getElementById('translatorModel')?.value || null,
             source_language: document.getElementById('translatorSourceLang')?.value || 'japanese',
@@ -6780,6 +7183,36 @@ const TranslatorManager = {
             // Debug checkbox lives in Transcription Adv. Options but is global
             debug: document.getElementById('debugLogging')?.checked || false
         };
+
+        // Ollama tuning knobs — only forward for the Ollama provider, and only
+        // when the user actually filled a field in (blank = curated default).
+        if (provider === 'ollama') {
+            const readNum = (id) => {
+                const el = document.getElementById(id);
+                if (!el || el.value === '' || el.value == null) return null;
+                const n = Number(el.value);
+                return Number.isFinite(n) ? n : null;
+            };
+            const numCtx       = readNum('translatorOllamaNumCtx');
+            const maxTokens    = readNum('translatorOllamaMaxTokens');
+            const temperature  = readNum('translatorOllamaTemperature');
+            const topP         = readNum('translatorOllamaTopP');
+            const topK         = readNum('translatorOllamaTopK');
+            const minP         = readNum('translatorOllamaMinP');
+            const repeatPen    = readNum('translatorOllamaRepeatPenalty');
+            const keepAlive    = document.getElementById('translatorOllamaKeepAlive')?.value?.trim() || null;
+
+            if (numCtx != null)      options.ollama_num_ctx = numCtx;
+            if (maxTokens != null)   options.ollama_max_tokens = maxTokens;
+            if (temperature != null) options.ollama_temperature = temperature;
+            if (topP != null)        options.ollama_top_p = topP;
+            if (topK != null)        options.ollama_top_k = topK;
+            if (minP != null)        options.ollama_min_p = minP;
+            if (repeatPen != null)   options.ollama_repeat_penalty = repeatPen;
+            if (keepAlive)           options.ollama_keep_alive = keepAlive;
+        }
+
+        return options;
     },
 
     async startTranslation() {
@@ -7052,7 +7485,13 @@ const TranslateIntegrationManager = {
                 maxBatchSize: fullSettings.maxBatchSize,
                 temperature: fullSettings.temperature,
                 topP: fullSettings.topP,
-                customEndpoint: fullSettings.customEndpoint
+                customEndpoint: fullSettings.customEndpoint,
+                ollamaNumCtx: fullSettings.ollamaNumCtx,
+                ollamaMaxTokens: fullSettings.ollamaMaxTokens,
+                ollamaTopK: fullSettings.ollamaTopK,
+                ollamaMinP: fullSettings.ollamaMinP,
+                ollamaRepeatPenalty: fullSettings.ollamaRepeatPenalty,
+                ollamaKeepAlive: fullSettings.ollamaKeepAlive
             };
         } else {
             // Transcription Mode settings
@@ -7084,7 +7523,7 @@ const TranslateIntegrationManager = {
 
         try {
             // Start translation via API - use correct key names matching api.py
-            const result = await pywebview.api.start_translation({
+            const payload = {
                 inputs: outputFiles,              // API expects 'inputs' not 'input_files'
                 provider: settings.provider,
                 target: settings.target,          // API expects 'target' not 'target_language'
@@ -7094,8 +7533,47 @@ const TranslateIntegrationManager = {
                 movie_title: settings.movieTitle || '',
                 actress: settings.actress || '',
                 movie_plot: settings.plot || '',
-                endpoint: settings.customEndpoint || ''
-            });
+                endpoint: settings.customEndpoint || '',
+                // Forward the global Debug checkbox so the ensemble translate
+                // subprocess gets --debug → PySubtrans logs the request body
+                // ("Request Body:\n{...}") sent to Ollama. Without this the
+                // ensemble path was always non-debug. (Transcription Adv.
+                // Options hosts the checkbox but it's global.)
+                debug: document.getElementById('debugLogging')?.checked || false
+            };
+            // Processing knobs from the ensemble translation modal (previously
+            // dropped — only provider/model/context reached the CLI).
+            if (settings.sceneThreshold) payload.scene_threshold = settings.sceneThreshold;
+            if (settings.maxBatchSize) payload.max_batch_size = settings.maxBatchSize;
+
+            // Ollama tuning — only for the ollama provider, only non-blank
+            // values (blank = curated default). Mirrors the SRT tab.
+            if (settings.provider === 'ollama') {
+                const num = (v) => {
+                    if (v === '' || v == null) return null;
+                    const n = Number(v);
+                    return Number.isFinite(n) ? n : null;
+                };
+                const numCtx = num(settings.ollamaNumCtx);
+                const maxTok = num(settings.ollamaMaxTokens);
+                const topK   = num(settings.ollamaTopK);
+                const minP   = num(settings.ollamaMinP);
+                const repPen = num(settings.ollamaRepeatPenalty);
+                const temp   = num(settings.temperature);
+                const topP   = num(settings.topP);
+                const keep   = (settings.ollamaKeepAlive || '').trim();
+
+                if (numCtx != null) payload.ollama_num_ctx = numCtx;
+                if (maxTok != null) payload.ollama_max_tokens = maxTok;
+                if (topK != null)   payload.ollama_top_k = topK;
+                if (minP != null)   payload.ollama_min_p = minP;
+                if (repPen != null) payload.ollama_repeat_penalty = repPen;
+                if (temp != null)   payload.ollama_temperature = temp;
+                if (topP != null)   payload.ollama_top_p = topP;
+                if (keep)           payload.ollama_keep_alive = keep;
+            }
+
+            const result = await pywebview.api.start_translation(payload);
 
             if (result.success) {
                 ConsoleManager.log('Translation started', 'success');
@@ -7203,7 +7681,15 @@ const TranslationSettingsModal = {
         temperature: 0.5,
         topP: 0.9,
         customEndpoint: '',
-        ollamaUrl: ''
+        ollamaUrl: '',
+        // Ollama tuning (blank/null = use curated default). temperature/topP
+        // above are reused for Ollama too.
+        ollamaNumCtx: '',
+        ollamaMaxTokens: '',
+        ollamaTopK: '',
+        ollamaMinP: '',
+        ollamaRepeatPenalty: '',
+        ollamaKeepAlive: ''
     },
 
     init() {
@@ -7230,7 +7716,7 @@ const TranslationSettingsModal = {
         document.getElementById('ensembleTranslateProvider')?.addEventListener('change', (e) => {
             ProviderUIManager.onProviderChange(e.target.value, 'ensemble');
             this.updateModelOptions(e.target.value);
-            // Show/hide Ollama URL field in settings modal
+            // Show/hide Ollama URL field + tuning section in settings modal
             document.querySelectorAll('.ollama-settings-row').forEach(el => {
                 el.style.display = (e.target.value === 'ollama') ? 'block' : 'none';
             });
@@ -7283,6 +7769,13 @@ const TranslationSettingsModal = {
         this.settings.topP = parseFloat(document.getElementById('translationTopP')?.value) || 0.9;
         this.settings.customEndpoint = document.getElementById('translationCustomEndpoint')?.value || '';
         this.settings.ollamaUrl = document.getElementById('translationOllamaUrl')?.value || '';
+        // Ollama tuning — keep raw string ('' = use curated default)
+        this.settings.ollamaNumCtx = document.getElementById('translationOllamaNumCtx')?.value || '';
+        this.settings.ollamaMaxTokens = document.getElementById('translationOllamaMaxTokens')?.value || '';
+        this.settings.ollamaTopK = document.getElementById('translationOllamaTopK')?.value || '';
+        this.settings.ollamaMinP = document.getElementById('translationOllamaMinP')?.value || '';
+        this.settings.ollamaRepeatPenalty = document.getElementById('translationOllamaRepeatPenalty')?.value || '';
+        this.settings.ollamaKeepAlive = document.getElementById('translationOllamaKeepAlive')?.value?.trim() || '';
 
         // Persist to localStorage (fast cache / fallback)
         try {
@@ -7347,6 +7840,14 @@ const TranslationSettingsModal = {
         document.getElementById('translationCustomEndpoint').value = this.settings.customEndpoint;
         const ollamaUrlEl = document.getElementById('translationOllamaUrl');
         if (ollamaUrlEl) ollamaUrlEl.value = this.settings.ollamaUrl || '';
+        // Ollama tuning fields (may not exist on older markup — guard each)
+        const setVal = (id, v) => { const el = document.getElementById(id); if (el) el.value = (v ?? ''); };
+        setVal('translationOllamaNumCtx', this.settings.ollamaNumCtx);
+        setVal('translationOllamaMaxTokens', this.settings.ollamaMaxTokens);
+        setVal('translationOllamaTopK', this.settings.ollamaTopK);
+        setVal('translationOllamaMinP', this.settings.ollamaMinP);
+        setVal('translationOllamaRepeatPenalty', this.settings.ollamaRepeatPenalty);
+        setVal('translationOllamaKeepAlive', this.settings.ollamaKeepAlive);
     },
 
     updateMultiFileWarning() {
@@ -7461,7 +7962,13 @@ const TranslationSettingsModal = {
             temperature: this.settings.temperature,
             topP: this.settings.topP,
             customEndpoint: this.settings.customEndpoint,
-            ollamaUrl: this.settings.ollamaUrl
+            ollamaUrl: this.settings.ollamaUrl,
+            ollamaNumCtx: this.settings.ollamaNumCtx,
+            ollamaMaxTokens: this.settings.ollamaMaxTokens,
+            ollamaTopK: this.settings.ollamaTopK,
+            ollamaMinP: this.settings.ollamaMinP,
+            ollamaRepeatPenalty: this.settings.ollamaRepeatPenalty,
+            ollamaKeepAlive: this.settings.ollamaKeepAlive
         };
     }
 };

--- a/whisperjav/webview_gui/assets/app.js
+++ b/whisperjav/webview_gui/assets/app.js
@@ -304,6 +304,9 @@ const SenseVoiceManager = {
     params: null,
     customized: false,
     defaults: {
+        model_id: 'iic/SenseVoiceSmall',
+        device: 'auto',
+        scene: 'auditok',
         use_itn: true,
         ban_emo_unk: false,
         merge_vad: true,
@@ -3060,9 +3063,15 @@ const EnsembleManager = {
     },
 
     generateSenseVoiceForm(schema, currentValues) {
-        // Use two existing tab slots: 'quality' -> Decoding, 'segmenter' -> VAD.
-        // Hide all the other tabs (model/enhancer/scene/context).
-        const tabMap = { quality: 'Decoding', segmenter: 'VAD' };
+        // Mirror the Transformers modal layout: Model / Quality / Chunking /
+        // Enhancer / Scene in the five standard tab slots; context stays hidden.
+        const tabMap = {
+            model: 'Model',
+            quality: 'Quality',
+            segmenter: 'Chunking',
+            enhancer: 'Enhancer',
+            scene: 'Scene'
+        };
         ['model', 'quality', 'segmenter', 'enhancer', 'scene', 'context'].forEach(tab => {
             const panel = document.getElementById(`tab-${tab}`);
             if (panel) panel.innerHTML = '';
@@ -3072,6 +3081,22 @@ const EnsembleManager = {
                 else { btn.style.display = 'none'; }
             }
         });
+
+        // Model tab: model id + device. NOTE: in ensemble the main-tab Model
+        // dropdown overrides model_id (pass_worker applies it after modal
+        // params); device has no main-tab equivalent so it always applies.
+        const modelTab = document.getElementById('tab-model');
+        const secM = schema.model || {};
+        if (secM.model_id) {
+            modelTab.appendChild(this.createTransformersDropdown('model_id', secM.model_id.label,
+                secM.model_id.options, currentValues.model_id || secM.model_id.default,
+                'FunASR/ModelScope model id. The Model dropdown on the main Ensemble row takes precedence when set.'));
+        }
+        if (secM.device) {
+            modelTab.appendChild(this.createTransformersDropdown('device', secM.device.label,
+                secM.device.options, currentValues.device || secM.device.default,
+                'Compute device (auto will detect GPU availability)'));
+        }
 
         const decoding = document.getElementById('tab-quality');
         const sec1 = schema.decoding || {};
@@ -3126,12 +3151,18 @@ const EnsembleManager = {
             bs.min, bs.max, bs.step, currentValues.batch_size_s ?? bs.default,
             'FunASR batch_size_s: total audio-seconds decoded per dynamic batch. Higher = faster throughput but more VRAM. Independent of subtitle timing.'));
 
-        // BS-RoFormer overlap (only meaningful when the BS-RoFormer enhancer is
-        // selected for this pass). Gated behind an enable checkbox so that when
-        // no speech enhancement is used we don't emit a floating bsrf_overlap
-        // into --passN-params. The gating checkbox is consumed locally and is
-        // NOT collected as a param (see applyCustomization's data-gating-toggle
+        // Enhancer tab: enhancer selection itself lives on the main Ensemble
+        // row (like Transformers); the modal only exposes the BS-RoFormer
+        // overlap knob. Gated behind an enable checkbox so that when no speech
+        // enhancement is used we don't emit a floating bsrf_overlap into
+        // --passN-params. The gating checkbox is consumed locally and is NOT
+        // collected as a param (see applyCustomization's data-gating-toggle
         // handling); the slider is skipped entirely when the box is unchecked.
+        const enhTab = document.getElementById('tab-enhancer');
+        const enhNote = document.createElement('p');
+        enhNote.className = 'tab-empty';
+        enhNote.innerHTML = 'Speech enhancement is selected in the main Ensemble tab.<br>This tab only tunes the BS-RoFormer enhancer when it is selected there.';
+        enhTab.appendChild(enhNote);
         const enhSec = schema.enhancer || {};
         if (enhSec.bsrf_overlap) {
             const ov = enhSec.bsrf_overlap;
@@ -3140,12 +3171,12 @@ const EnsembleManager = {
             const gate = this.createParamGateToggle('enable_bsrf_overlap',
                 'Override BS-RoFormer overlap', overlapEnabled,
                 'Only applies when this pass uses the BS-RoFormer speech enhancer. Leave off to use its default overlap (2).');
-            vad.appendChild(gate);
-            vad.appendChild(this.createTransformersSlider('bsrf_overlap', ov.label,
+            enhTab.appendChild(gate);
+            enhTab.appendChild(this.createTransformersSlider('bsrf_overlap', ov.label,
                 ov.min, ov.max, ov.step, currentValues.bsrf_overlap ?? ov.default,
                 'BS-RoFormer chunk overlap — lower = faster separation, slight quality cost (only used when Speech Enhancer = BS-RoFormer)'));
             // Tie the slider control to the gate so the collector skips it when off.
-            const ovCtrl = vad.querySelector('.param-control[data-param="bsrf_overlap"]');
+            const ovCtrl = enhTab.querySelector('.param-control[data-param="bsrf_overlap"]');
             if (ovCtrl) {
                 ovCtrl.dataset.gatedBy = 'enable_bsrf_overlap';
                 ovCtrl.style.opacity = overlapEnabled ? '1' : '0.5';
@@ -3163,13 +3194,25 @@ const EnsembleManager = {
             }
         }
 
+        // Scene tab. NOTE: in ensemble the main-tab Scene Detector dropdown
+        // overrides this when set (pass_worker applies it after modal params)
+        // — same precedence as the Transformers modal's Scene tab.
+        const sceneTab = document.getElementById('tab-scene');
+        const secSc = schema.scene || {};
+        if (secSc.scene) {
+            sceneTab.appendChild(this.createTransformersDropdown('scene', secSc.scene.label,
+                secSc.scene.options, currentValues.scene || secSc.scene.default,
+                'Split audio into scenes before transcription — this sets subtitle granularity for SenseVoice. The Scene Detector dropdown on the main Ensemble row takes precedence when set.'));
+        }
+
         // Mark integer sliders so applyCustomization parses them as ints.
-        ['merge_length_s', 'vad_max_segment_ms', 'batch_size_s', 'bsrf_overlap'].forEach(p => {
-            const ctrl = document.querySelector(`#tab-segmenter .param-control[data-param="${p}"]`);
+        [['tab-segmenter', 'merge_length_s'], ['tab-segmenter', 'vad_max_segment_ms'],
+         ['tab-segmenter', 'batch_size_s'], ['tab-enhancer', 'bsrf_overlap']].forEach(([tabId, p]) => {
+            const ctrl = document.querySelector(`#${tabId} .param-control[data-param="${p}"]`);
             if (ctrl) ctrl.dataset.originalType = 'int';
         });
 
-        this.switchModalTab('quality');
+        this.switchModalTab('model');
     },
 
     // Generic checkbox control (no Transformers-specific helper exists).

--- a/whisperjav/webview_gui/assets/index.html
+++ b/whisperjav/webview_gui/assets/index.html
@@ -214,6 +214,7 @@
                                             <option value="kotoba-faster-whisper">kotoba&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(kotoba-v2-fp16&nbsp;&nbsp;&nbsp;6GB VRAM)</option>
                                             -->
                                             <option value="transformers">transformers&nbsp;&nbsp;(HF kotoba-bilingual&nbsp;6GB VRAM)</option>
+                                            <option value="sensevoice">sensevoice&nbsp;&nbsp;&nbsp;(FunASR Small&nbsp;&nbsp;&nbsp;&nbsp;~1GB VRAM)</option>
                                             <option value="anime" disabled>anime (future placeholder)</option>
                                         </select>
                                     </div>
@@ -356,6 +357,54 @@
                                     </label>
                                 </div>
                             </div>
+
+                            <!-- Row 4: Batched transcription (balanced pipeline speedup, issue #357) -->
+                            <div class="form-row" id="adv-row-4">
+                                <div class="form-group">
+                                    <label class="checkbox-label" title="Batch the encoder across VAD groups using faster-whisper BatchedInferencePipeline. 5-20x faster transcription on GPU for the balanced pipeline. No effect on other modes.">
+                                        <input type="checkbox" id="batchedPipeline" checked>
+                                        <span>Batched transcription (balanced — faster)</span>
+                                    </label>
+                                </div>
+                                <div class="form-group tight-pair" id="batchSizeGroup">
+                                    <label for="batchSize" class="form-label" style="white-space: nowrap;">Batch size:</label>
+                                    <input
+                                        type="number"
+                                        id="batchSize"
+                                        class="form-input"
+                                        min="1"
+                                        max="32"
+                                        step="1"
+                                        value="8"
+                                        style="width: 5rem;"
+                                        title="Number of VAD groups decoded in parallel. Higher = faster but more VRAM. Default: 8."
+                                    >
+                                </div>
+                            </div>
+
+                            <!-- Row 5: SenseVoice diarization (single-pass; only applies to --mode sensevoice) -->
+                            <div class="form-row" id="adv-row-sv-diarize" style="display: none;">
+                                <div class="form-group">
+                                    <label class="checkbox-label" title="Speaker diarization (FunASR cam++): adds per-sentence [spkN] labels. Runs SenseVoice on the full audio (scene detection is auto-disabled) so speaker ids stay consistent. Downloads the cam++ model on first use.">
+                                        <input type="checkbox" id="svDiarize">
+                                        <span>Speaker diarization ([spkN] labels) — SenseVoice only</span>
+                                    </label>
+                                </div>
+                                <div class="form-group tight-pair" id="svSpkNumGroup">
+                                    <label for="svSpkNum" class="form-label" style="white-space: nowrap;">Speakers:</label>
+                                    <input
+                                        type="number"
+                                        id="svSpkNum"
+                                        class="form-input"
+                                        min="0"
+                                        max="10"
+                                        step="1"
+                                        value="0"
+                                        style="width: 5rem;"
+                                        title="Force a fixed speaker count. 0 = auto-detect (cam++ often collapses to 1 on breathy/monologue audio). Set 2+ when you know how many speakers the scene has."
+                                    >
+                                </div>
+                            </div>
                         </div>
 
                         <!-- Tab 3: Two-Pass Ensemble Mode -->
@@ -394,6 +443,9 @@
                                             </optgroup>
                                             <optgroup label="HuggingFace">
                                                 <option value="transformers">Transformers (HF)</option>
+                                            </optgroup>
+                                            <optgroup label="FunASR">
+                                                <option value="sensevoice">SenseVoice (Small)</option>
                                             </optgroup>
                                             <optgroup label="ChronosJAV">
                                                 <option value="qwen">Qwen3-ASR</option>
@@ -436,7 +488,7 @@
                                                 <option value="clearvoice:MossFormer2_SS_16K">MossFormer2 SS 16kHz</option>
                                             </optgroup>
                                             <optgroup label="BS-RoFormer">
-                                                <option value="bs-roformer:vocals" disabled class="coming-soon">Vocals (Coming Soon)</option>
+                                                <option value="bs-roformer:vocals" title="Band-Split RoFormer vocal isolation — separates speech from music/background (44.1kHz). Requires the bs-roformer-infer package.">Vocals</option>
                                             </optgroup>
                                         </select>
                                         <div class="enhance-for-vad-row" id="pass1-enhance-vad-row" style="display: none;">
@@ -551,6 +603,9 @@
                                             <optgroup label="HuggingFace">
                                                 <option value="transformers">Transformers (HF)</option>
                                             </optgroup>
+                                            <optgroup label="FunASR">
+                                                <option value="sensevoice">SenseVoice (Small)</option>
+                                            </optgroup>
                                             <optgroup label="ChronosJAV">
                                                 <option value="qwen" selected>Qwen3-ASR</option>
                                                 <option value="anime-whisper">Anime-Whisper</option>
@@ -595,7 +650,7 @@
                                                 <option value="clearvoice:MossFormer2_SS_16K">MossFormer2 SS 16kHz</option>
                                             </optgroup>
                                             <optgroup label="BS-RoFormer">
-                                                <option value="bs-roformer:vocals" disabled class="coming-soon">Vocals (Coming Soon)</option>
+                                                <option value="bs-roformer:vocals" title="Band-Split RoFormer vocal isolation — separates speech from music/background (44.1kHz). Requires the bs-roformer-infer package.">Vocals</option>
                                             </optgroup>
                                         </select>
                                         <div class="enhance-for-vad-row" id="pass2-enhance-vad-row" style="display: none;">
@@ -987,6 +1042,48 @@
                                         <div class="form-group" style="grid-column: span 2;">
                                             <label for="translatorCustomEndpoint" class="form-label">Custom Endpoint URL:</label>
                                             <input type="text" id="translatorCustomEndpoint" class="form-input" placeholder="https://api.example.com/v1 (for OpenAI-compatible APIs)">
+                                        </div>
+
+                                        <!-- Ollama tuning (shown only when provider = Ollama) -->
+                                        <div class="form-group" id="translatorOllamaTuning" style="grid-column: span 2; display:none;">
+                                            <div class="section-header-inline" style="margin-bottom:6px;">
+                                                <span class="section-title">Ollama Tuning</span>
+                                                <span class="section-note">(leave blank for model defaults)</span>
+                                            </div>
+                                            <div class="translator-advanced-grid">
+                                                <div class="form-group" title="Token budget for the whole prompt+reply per batch. Larger lets more subtitle lines fit per request (batch size is auto-recomputed from this).&#10;ACCURACY: higher avoids context overflow that truncates/garbles output and drops lines.&#10;SPEED: slightly slower per batch, but fewer batches overall.&#10;VRAM: HIGHER COST — KV cache grows with context (8192→16384 adds ~1-2GB on a 12B model). 4070/12GB: 16384 is safe with a Q4 12B model.&#10;Blank = model default (often 8192).">
+                                                    <label for="translatorOllamaNumCtx" class="form-label">Context Window (num_ctx):</label>
+                                                    <input type="number" id="translatorOllamaNumCtx" class="form-input" placeholder="e.g. 16384" min="2048" max="131072" step="1024">
+                                                </div>
+                                                <div class="form-group" title="Hard cap on tokens the model may generate per batch.&#10;ACCURACY: too low truncates the reply mid-batch (lost lines); auto value is sized to the batch.&#10;SPEED: a tighter cap can end runaway/garbled generations sooner.&#10;VRAM: no real effect.&#10;Blank = auto (computed from context + batch size).">
+                                                    <label for="translatorOllamaMaxTokens" class="form-label">Max Output Tokens:</label>
+                                                    <input type="number" id="translatorOllamaMaxTokens" class="form-input" placeholder="auto" min="256" max="32768" step="256">
+                                                </div>
+                                                <div class="form-group" title="Randomness of word choice.&#10;ACCURACY: lower (0.2-0.4) = more literal, consistent, fewer hallucinations — best for subtitles; higher = more creative but more drift/invented lines.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 0.3 (tuned for JA→EN subtitles).">
+                                                    <label for="translatorOllamaTemperature" class="form-label">Temperature:</label>
+                                                    <input type="number" id="translatorOllamaTemperature" class="form-input" placeholder="auto (0.3)" min="0" max="2" step="0.05">
+                                                </div>
+                                                <div class="form-group" title="Nucleus sampling: keep only the most probable tokens summing to this probability.&#10;ACCURACY: lower (0.9-0.92) trims unlikely/garbage tokens, steadier output; 1.0 disables it.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 0.92.">
+                                                    <label for="translatorOllamaTopP" class="form-label">Top P:</label>
+                                                    <input type="number" id="translatorOllamaTopP" class="form-input" placeholder="0.92" min="0" max="1" step="0.01">
+                                                </div>
+                                                <div class="form-group" title="Limit choices to the K most likely tokens each step.&#10;ACCURACY: lower (40-50) curbs hallucination and off-topic words; very low can sound stiff.&#10;SPEED: negligible.&#10;VRAM: no effect.&#10;Blank = 50.">
+                                                    <label for="translatorOllamaTopK" class="form-label">Top K:</label>
+                                                    <input type="number" id="translatorOllamaTopK" class="form-input" placeholder="50" min="1" max="200" step="1">
+                                                </div>
+                                                <div class="form-group" title="Discard tokens below this fraction of the top token's probability.&#10;ACCURACY: a small floor (0.05) removes long-tail noise that causes blank/garbled lines.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 0.05.">
+                                                    <label for="translatorOllamaMinP" class="form-label">Min P:</label>
+                                                    <input type="number" id="translatorOllamaMinP" class="form-input" placeholder="0.05" min="0" max="1" step="0.01">
+                                                </div>
+                                                <div class="form-group" title="Penalty applied to already-used tokens.&#10;ACCURACY: higher (1.1-1.2) stops the model repeating a line or looping on moans/short ASR fragments — a common cause of dropped/duplicate subtitles; too high (over 1.3) can hurt fluency.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 1.1.">
+                                                    <label for="translatorOllamaRepeatPenalty" class="form-label">Repeat Penalty:</label>
+                                                    <input type="number" id="translatorOllamaRepeatPenalty" class="form-input" placeholder="1.1" min="0.5" max="2" step="0.05">
+                                                </div>
+                                                <div class="form-group" title="How long Ollama keeps the model loaded in VRAM between batches.&#10;ACCURACY: none.&#10;SPEED: longer (e.g. 30m, or -1 = forever) avoids a multi-second reload before each file/batch; 0 unloads immediately.&#10;VRAM: keeps it OCCUPIED while idle (use 0 to free VRAM for other apps between runs).&#10;Blank = Ollama default (~5m). Values: 30m, 1h, -1, 0.">
+                                                    <label for="translatorOllamaKeepAlive" class="form-label">Keep Alive:</label>
+                                                    <input type="text" id="translatorOllamaKeepAlive" class="form-input" placeholder="e.g. 30m, -1, 0">
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </details>
@@ -1395,11 +1492,11 @@
                             </div>
                         </div>
                         <div class="form-row">
-                            <div class="form-group">
+                            <div class="form-group" title="Randomness of word choice (applies to cloud providers AND Ollama).&#10;ACCURACY: lower (0.2-0.4) = more literal, consistent, fewer hallucinations — best for subtitles; higher = more creative but more drift/invented lines.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;For Ollama, 0.3 is the tuned default.">
                                 <label for="translationTemperature" class="form-label">Temperature:</label>
                                 <input type="number" id="translationTemperature" class="form-input" value="0.5" min="0" max="2" step="0.1">
                             </div>
-                            <div class="form-group">
+                            <div class="form-group" title="Nucleus sampling: keep only the most probable tokens summing to this probability (cloud providers AND Ollama).&#10;ACCURACY: lower (0.9-0.92) trims unlikely/garbage tokens, steadier output; 1.0 disables it.&#10;SPEED: no effect.&#10;VRAM: no effect.">
                                 <label for="translationTopP" class="form-label">Top P:</label>
                                 <input type="number" id="translationTopP" class="form-input" value="0.9" min="0" max="1" step="0.1">
                             </div>
@@ -1414,6 +1511,43 @@
                             <div class="form-group full-width">
                                 <label for="translationOllamaUrl" class="form-label">Ollama Server URL:</label>
                                 <input type="text" id="translationOllamaUrl" class="form-input" placeholder="http://localhost:11434 (leave empty for default)">
+                            </div>
+                        </div>
+                        <!-- Ollama tuning (shown only when provider = Ollama) -->
+                        <div class="ollama-settings-row" id="translationOllamaTuning" style="display:none">
+                            <div class="section-header-inline" style="margin-bottom:6px;">
+                                <span class="section-title">Ollama Tuning</span>
+                                <span class="section-note">(leave blank for model defaults)</span>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group" title="Token budget for the whole prompt+reply per batch. Larger lets more subtitle lines fit per request (batch size is auto-recomputed from this).&#10;ACCURACY: higher avoids context overflow that truncates/garbles output and drops lines.&#10;SPEED: slightly slower per batch, but fewer batches overall.&#10;VRAM: HIGHER COST — KV cache grows with context (8192→16384 adds ~1-2GB on a 12B model). 4070/12GB: 16384 is safe with a Q4 12B model.&#10;Blank = model default (often 8192).">
+                                    <label for="translationOllamaNumCtx" class="form-label">Context Window (num_ctx):</label>
+                                    <input type="number" id="translationOllamaNumCtx" class="form-input" placeholder="e.g. 16384" min="2048" max="131072" step="1024">
+                                </div>
+                                <div class="form-group" title="Hard cap on tokens the model may generate per batch.&#10;ACCURACY: too low truncates the reply mid-batch (lost lines); auto value is sized to the batch.&#10;SPEED: a tighter cap can end runaway/garbled generations sooner.&#10;VRAM: no real effect.&#10;Blank = auto (computed from context + batch size).">
+                                    <label for="translationOllamaMaxTokens" class="form-label">Max Output Tokens:</label>
+                                    <input type="number" id="translationOllamaMaxTokens" class="form-input" placeholder="auto" min="256" max="32768" step="256">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group" title="Limit choices to the K most likely tokens each step.&#10;ACCURACY: lower (40-50) curbs hallucination and off-topic words; very low can sound stiff.&#10;SPEED: negligible.&#10;VRAM: no effect.&#10;Blank = 50.">
+                                    <label for="translationOllamaTopK" class="form-label">Top K:</label>
+                                    <input type="number" id="translationOllamaTopK" class="form-input" placeholder="50" min="1" max="200" step="1">
+                                </div>
+                                <div class="form-group" title="Discard tokens below this fraction of the top token's probability.&#10;ACCURACY: a small floor (0.05) removes long-tail noise that causes blank/garbled lines.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 0.05.">
+                                    <label for="translationOllamaMinP" class="form-label">Min P:</label>
+                                    <input type="number" id="translationOllamaMinP" class="form-input" placeholder="0.05" min="0" max="1" step="0.01">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group" title="Penalty applied to already-used tokens.&#10;ACCURACY: higher (1.1-1.2) stops the model repeating a line or looping on moans/short ASR fragments — a common cause of dropped/duplicate subtitles; too high (over 1.3) can hurt fluency.&#10;SPEED: no effect.&#10;VRAM: no effect.&#10;Blank = 1.1.">
+                                    <label for="translationOllamaRepeatPenalty" class="form-label">Repeat Penalty:</label>
+                                    <input type="number" id="translationOllamaRepeatPenalty" class="form-input" placeholder="1.1" min="0.5" max="2" step="0.05">
+                                </div>
+                                <div class="form-group" title="How long Ollama keeps the model loaded in VRAM between batches.&#10;ACCURACY: none.&#10;SPEED: longer (e.g. 30m, or -1 = forever) avoids a multi-second reload before each file/batch; 0 unloads immediately.&#10;VRAM: keeps it OCCUPIED while idle (use 0 to free VRAM for other apps between runs).&#10;Blank = Ollama default (~5m). Values: 30m, 1h, -1, 0.">
+                                    <label for="translationOllamaKeepAlive" class="form-label">Keep Alive:</label>
+                                    <input type="text" id="translationOllamaKeepAlive" class="form-input" placeholder="e.g. 30m, -1, 0">
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/whisperjav/webview_gui/assets/style.css
+++ b/whisperjav/webview_gui/assets/style.css
@@ -188,9 +188,24 @@ body {
 
 .app-main {
     flex: 1;
+    min-height: 0;  /* allow children to shrink/grow inside the flex column */
     overflow-y: auto;
     padding: 8px 12px;  /* AGGRESSIVE: Reduced from 10px 14px */
     background: var(--content-area-bg);
+    /* Flex column so the console section can grow to fill leftover vertical
+       space instead of stopping at a fixed height (grey gap below console). */
+    display: flex;
+    flex-direction: column;
+}
+
+/* Upper sections keep their natural height; only the console grows. Without
+   this, making .app-main a flex column would let the content sections be
+   squished when the window is short. */
+.app-main > .source-section,
+.app-main > .destination-section,
+.app-main > .tabs-section,
+.app-main > .run-section {
+    flex-shrink: 0;
 }
 
 .app-footer {
@@ -865,6 +880,7 @@ body {
    ============================================================ */
 .console-section {
     flex: 1;
+    min-height: 0;  /* let the flex child (console) own the scroll, not overflow the column */
     display: flex;
     flex-direction: column;
     margin-bottom: 0;
@@ -872,6 +888,7 @@ body {
 
 .console-section .section-content {
     flex: 1;
+    min-height: 0;  /* same: required for .console-output overflow-y to work when tall */
     display: flex;
     padding: 0;
 }
@@ -887,8 +904,11 @@ body {
     white-space: pre-wrap;
     word-wrap: break-word;
     line-height: 1.45;  /* AGGRESSIVE: Slightly reduced from 1.5 */
-    min-height: 280px;  /* AGGRESSIVE: INCREASED from 250px (more console space!) */
-    max-height: 400px;  /* Fixed height for dedicated scrollbar and auto-scroll */
+    min-height: 200px;  /* Floor for short windows (then .app-main scrolls) */
+    /* No max-height: flex:1 (via .console-section/.section-content) lets the
+       console fill all leftover vertical space down to the footer, so there's
+       no grey gap below it on tall windows. Its own overflow-y keeps the log
+       scrollable + auto-scrolling. */
     scroll-behavior: smooth;  /* Smooth auto-scroll animation */
 }
 


### PR DESCRIPTION
## What this is

A bundle of local customizations made on top of the 1.8.14 install. Opened **as a draft** for visibility/discussion — it is intentionally broad and **not** split per-feature yet.

> [!WARNING]
> **Heads-up for the maintainer / reviewer — this is not yet a clean, mergeable PR.**
> - It bundles **four unrelated features** in one commit (would normally be split).
> - It was branched from `main`, but the source was captured from an installed **1.8.14 wheel** that predates current `main`. On files that changed on both sides (e.g. `main.py`, `modules/faster_whisper_pro_asr.py`) the diff may **revert** newer upstream work — review those carefully.
> - `config/builder.py`, `config/resolver.py`, `config/transcription_tuner.py` appear as **new** files only because they were present in the 1.8.14 wheel; if upstream removed/refactored them since, those additions are spurious.
> - `config/asr_config.json` (runtime-resolved state) was deliberately excluded.

## Features included

- **AI SRT Translate — Ollama tuning.** Bake `num_ctx` + sampling into a per-config `whisperjav-<hash>` Ollama model variant (Ollama's OpenAI-compatible endpoint silently ignores top-level `num_ctx`/`top_k`/`top_p`/`repeat_penalty`); fix HTTP 400 on `/api/create` for Ollama ≥ 0.30 (structured `{from, parameters}` payload + legacy fallback); expose `--ollama-*` CLI flags and GUI tuning controls in both the SRT-Translate tab and the ensemble translation modal, with per-line accuracy/speed/VRAM tooltips; console-fill CSS fix.
- **SenseVoice backend.** `modules/sensevoice_asr.py`, `pipelines/sensevoice_pipeline.py`, `--mode sensevoice` with `--sv-*` flags, GUI mode option + ensemble pass, optional diarization, relaxed (non-Whisper) sanitizer toggles.
- **BS-RoFormer enhancer rewrite** for the real `bs-roformer` 0.1.1 API, Revive2 checkpoint self-download, configurable inference overlap.
- **Batched faster-whisper** (`BatchedInferencePipeline`) in the balanced pipeline.

## Suggested path to merge

If you'd like to take any of this, the **Ollama translate tuning** is the most self-contained and could be cherry-picked into a focused PR rebased on current `main`. Happy to split it out.
