### PR TITLE
GUI: add Auto-scroll toggle to the Console

### DIFF
--- a/whisperjav/webview_gui/assets/app.js
+++ b/whisperjav/webview_gui/assets/app.js
@@ -779,7 +779,14 @@ const ConsoleManager = {
         line.textContent = message;
         output.appendChild(line);
 
-        // Auto-scroll to bottom (use requestAnimationFrame to ensure DOM updated)
+        this._autoScroll(output);
+    },
+
+    // Scroll to bottom unless the user unchecked the Auto-scroll toggle.
+    // requestAnimationFrame ensures the DOM has been updated first.
+    _autoScroll(output) {
+        const toggle = document.getElementById('consoleAutoScroll');
+        if (toggle && !toggle.checked) return;
         requestAnimationFrame(() => {
             if (output) {
                 output.scrollTop = output.scrollHeight;
@@ -808,12 +815,7 @@ const ConsoleManager = {
             output.appendChild(lineEl);
         });
 
-        // Auto-scroll to bottom (use requestAnimationFrame to ensure DOM updated)
-        requestAnimationFrame(() => {
-            if (output) {
-                output.scrollTop = output.scrollHeight;
-            }
-        });
+        this._autoScroll(output);
     }
 };
 

--- a/whisperjav/webview_gui/assets/index.html
+++ b/whisperjav/webview_gui/assets/index.html
@@ -1040,9 +1040,15 @@
             <section class="section console-section">
                 <div class="section-header">
                     <h2>Console</h2>
-                    <button type="button" class="btn btn-text btn-sm" id="clearConsoleBtn">
-                        Clear
-                    </button>
+                    <div style="display: flex; align-items: center; gap: 12px;">
+                        <label class="checkbox-label" title="Keep the console scrolled to the newest line">
+                            <input type="checkbox" id="consoleAutoScroll" checked>
+                            <span>Auto-scroll</span>
+                        </label>
+                        <button type="button" class="btn btn-text btn-sm" id="clearConsoleBtn">
+                            Clear
+                        </button>
+                    </div>
                 </div>
                 <div class="section-content">
                     <div class="console-output" id="consoleOutput">


### PR DESCRIPTION
﻿The GUI console always force-scrolls to the newest line, which makes it impossible to scroll back and read earlier output while a run is streaming (long ensemble runs produce thousands of lines).

This adds an **Auto-scroll** checkbox next to the console's Clear button:
- **Checked (default):** current behavior, console follows the tail.
- **Unchecked:** the scrollbar stays where the user put it while output keeps appending; re-checking snaps back to the bottom.

Implementation: both console writers (`ConsoleManager.log` and `ConsoleManager.appendRaw`) now route through a shared `_autoScroll()` helper that checks the toggle before scrolling. No behavior change for anyone who never touches the checkbox.

Unlike my other open PRs, this one is based directly on current `main` and is independently mergeable.
