### PR TITLE
translate: add 'contextual' tone (explicit only where the original is explicit)

### DIFF
--- a/whisperjav/main.py
+++ b/whisperjav/main.py
@@ -406,9 +406,10 @@ def parse_arguments():
     )
     translation_group.add_argument(
         "--translate-tone",
-        choices=["standard", "pornify"],
+        choices=["standard", "contextual", "pornify"],
         default="standard",
-        help="Translation style (default: standard)"
+        help="Translation style: standard, contextual (explicit only where the "
+             "original is explicit), pornify (default: standard)"
     )
     translation_group.add_argument(
         "--translate-api-key",

--- a/whisperjav/translate/cli.py
+++ b/whisperjav/translate/cli.py
@@ -242,9 +242,11 @@ def main():
     )
     translation_group.add_argument(
         '--tone',
-        choices=['standard', 'pornify'],
+        choices=['standard', 'contextual', 'pornify'],
         default=None,
-        help=f"Translation tone/style (default: {settings.get('tone', 'standard')})"
+        help=f"Translation tone/style: standard (faithful), contextual (explicit only "
+             f"where the original is explicit), pornify (everything explicit) "
+             f"(default: {settings.get('tone', 'standard')})"
     )
 
     # API configuration

--- a/whisperjav/translate/cli.py
+++ b/whisperjav/translate/cli.py
@@ -84,7 +84,8 @@ def generate_output_path(input_path: str, target_lang: str) -> str:
     return str(input_path.parent / output_name)
 
 
-def build_provider_options(args, settings_model_params: dict, effective_tone: str) -> dict:
+def build_provider_options(args, settings_model_params: dict, effective_tone: str,
+                           settings_tone: str = None) -> dict:
     """Build provider options with correct precedence and tone-aware defaults.
 
     Precedence: CLI > settings > defaults (tone-aware).
@@ -92,6 +93,9 @@ def build_provider_options(args, settings_model_params: dict, effective_tone: st
       - standard:   temperature=0.5, top_p=0.9
       - contextual: temperature=0.8, top_p=0.9
       - pornify:    temperature=1.2, top_p=0.9
+    settings_tone is the tone SAVED IN the settings file (not the effective
+    run tone) — the settings temperature only applies when both match, see
+    step 2 below.
     Keep in sync with translate/service.py _build_provider_options.
     """
     def _to_float(val):
@@ -111,11 +115,19 @@ def build_provider_options(args, settings_model_params: dict, effective_tone: st
         temperature = 0.5
         top_p = 0.9
 
-    # 2) Apply settings overrides (if provided and not None)
+    # 2) Apply settings overrides (if provided and not None).
+    #    temperature is TONE-COUPLED: the GUI settings modal persists its
+    #    Temperature field unconditionally (stock 0.5), so a value saved
+    #    alongside tone X must not override tone Y's tuned default —
+    #    otherwise one Save with tone=standard pins 0.5 forever and
+    #    contextual/pornify never see their 0.8/1.2 defaults. Honor the
+    #    settings temperature only when the file was saved for the same
+    #    tone this run uses. top_p has the same default for every tone,
+    #    so it passes through unconditionally.
     if settings_model_params:
         s_temp = settings_model_params.get('temperature', None)
         s_top_p = settings_model_params.get('top_p', None)
-        if s_temp is not None:
+        if s_temp is not None and (settings_tone or 'standard') == effective_tone:
             f = _to_float(s_temp)
             if f is not None:
                 temperature = f
@@ -534,9 +546,12 @@ def main():
     # Resolve instruction file
     instruction_file = resolve_instruction_file_or_content(args, merged)
 
-    # Build provider options (tone-aware defaults, settings, then CLI)
+    # Build provider options (tone-aware defaults, settings, then CLI).
+    # settings.get('tone') is the tone the file was SAVED with — the saved
+    # temperature only applies when it matches the effective run tone.
     effective_tone = merged.get('tone') or 'standard'
-    provider_options = build_provider_options(args, merged.get('model_params', {}), effective_tone)
+    provider_options = build_provider_options(args, merged.get('model_params', {}), effective_tone,
+                                              settings_tone=settings.get('tone'))
 
     # Build extra context
     extra_context = build_extra_context(args)
@@ -629,17 +644,23 @@ def main():
             provider_options['num_ctx'] = ollama_n_ctx
 
         # Ollama temperature override for local LLMs.
-        # build_provider_options() always sets temperature (0.5 standard / 1.2
-        # pornify) — these are cloud-provider defaults. Local models need lower
-        # temperature (0.3 best-fit across 10 tested models). Override the
-        # generic default with the Ollama-optimized value, but ONLY when:
+        # build_provider_options() seeds the cloud-provider default for the
+        # standard tone (0.5). Local models prefer lower temperature (0.3
+        # best-fit across 10 tested models). Override that generic default
+        # with the Ollama-optimized value, but ONLY when:
         #   - User did NOT set --temperature on CLI
-        #   - User did NOT set temperature in settings file
-        #   - Tone is NOT pornify (pornify's 1.2 is an intentional user choice)
+        #   - User did NOT set temperature in settings file FOR THIS TONE
+        #     (the settings temperature is tone-coupled, see
+        #     build_provider_options step 2)
+        #   - Tone is standard — pornify's 1.2 and contextual's 0.8 are
+        #     intentional tone-tuned values, not generic defaults
         _user_set_temp_cli = hasattr(args, 'temperature') and args.temperature is not None
-        _user_set_temp_settings = bool(merged.get('model_params', {}).get('temperature'))
+        _user_set_temp_settings = (
+            bool(merged.get('model_params', {}).get('temperature'))
+            and (settings.get('tone') or 'standard') == effective_tone
+        )
         if not _user_set_temp_cli and not _user_set_temp_settings:
-            if effective_tone != 'pornify':
+            if effective_tone not in ('pornify', 'contextual'):
                 provider_options['temperature'] = readiness.get('temperature', 0.3)
 
         provider_config = dict(provider_config)

--- a/whisperjav/translate/cli.py
+++ b/whisperjav/translate/cli.py
@@ -89,8 +89,10 @@ def build_provider_options(args, settings_model_params: dict, effective_tone: st
 
     Precedence: CLI > settings > defaults (tone-aware).
     Defaults:
-      - standard: temperature=0.5, top_p=0.9
-      - pornify:  temperature=1.2, top_p=0.9
+      - standard:   temperature=0.5, top_p=0.9
+      - contextual: temperature=0.8, top_p=0.9
+      - pornify:    temperature=1.2, top_p=0.9
+    Keep in sync with translate/service.py _build_provider_options.
     """
     def _to_float(val):
         try:
@@ -101,6 +103,9 @@ def build_provider_options(args, settings_model_params: dict, effective_tone: st
     # 1) Start from tone-aware defaults
     if effective_tone == 'pornify':
         temperature = 1.2
+        top_p = 0.9
+    elif effective_tone == 'contextual':
+        temperature = 0.8
         top_p = 0.9
     else:
         temperature = 0.5

--- a/whisperjav/translate/defaults/contextual.txt
+++ b/whisperjav/translate/defaults/contextual.txt
@@ -1,0 +1,60 @@
+### prompt
+Please translate the following subtitles[ for movie][ to language].
+
+### instructions
+You are a professional translator specializing in Japanese adult video (JAV) subtitles. Your mission: translate each line so its explicitness **matches the explicitness of the original** — explicit scenes get explicit, vulgar language; ordinary dialogue stays ordinary.
+
+**The one rule that overrides everything else: match the source.**
+- **Neutral dialogue stays neutral.** Greetings, small talk, plot conversation, interviews, names, questions like "where are you from?" must be translated naturally and plainly — do NOT sexualize, flirt up, or add innuendo that is not in the original.
+- **Suggestive dialogue stays suggestive.** Teasing and innuendo should be translated as teasing and innuendo — playful, not graphic.
+- **Explicit dialogue goes full strength.** When the original is sexual (dirty talk, sex acts, moaning with words), use raw, natural porn language — "fuck me harder," "your cock feels so good" — never clinical or euphemistic.
+
+**Escalation arc:** JAV typically starts with polite conversation and builds to explicit sex. Let your translation follow the *original's* arc — do not run ahead of it. The interview before the scene is not yet porn; translate it as an interview.
+
+**Other rules:**
+- **Fix AI errors**: The subtitles are AI-generated (Whisper) and may contain transcription errors. Use context to infer the intended line, but never invent dialogue that is not there.
+- **Personality matters**: A shy speaker sounds shy, a dominant one commanding, a tease playful — in both neutral and explicit registers.
+- **One-to-one line translation**: Each original line must have exactly one translated line. Never merge lines.
+- **Keep it concise**: Subtitles must be readable on screen — short and punchy.
+- **Names**: Use the user's preferred spelling.
+- **No verbal tics**: Do not pad lines with repetitive pet names or filler ("baby", "babe", "honey") unless the original actually contains an endearment. Vary phrasing across lines; never reuse the same stock phrase repeatedly.
+- **Profanity**: Translate profanity at the same intensity as the original — no stronger, no weaker.
+- **Context**: Use any provided context to judge how explicit a scene actually is.
+
+**Output Format:**
+```
+#LINE_NUMBER
+Original> [original text]
+Translation> [translation]
+```
+
+**At the end, include:**
+```
+<summary>
+A one- or two-line synopsis of the current batch.
+</summary>
+<scene>
+A short summary of the current scene, including any previous batches.
+</scene>
+```
+
+**Example:**
+```
+#12
+Original> 今日はどこから来たんですか？
+Translation> So where did you come from today?
+
+#200
+Original> もっと優しくして…
+Translation> Be gentle with me…
+
+#501
+Original> もう我慢できない！
+Translation> I can't take it anymore — I need you inside me NOW!
+```
+
+### retry_instructions
+Your last translation did not follow the rules. Please translate the subtitles again, ensuring:
+- **Every line is translated separately** — no merging, keep the line count exact.
+- **Explicitness matches the original** — neutral lines stay neutral, explicit lines stay explicit.
+- **No invented dialogue** — only translate what is there.

--- a/whisperjav/translate/service.py
+++ b/whisperjav/translate/service.py
@@ -128,7 +128,8 @@ def _build_provider_options(
     tone: str = "standard",
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
-    settings_model_params: Optional[dict] = None
+    settings_model_params: Optional[dict] = None,
+    settings_tone: Optional[str] = None
 ) -> dict:
     """
     Build provider options with tone-aware defaults.
@@ -140,6 +141,11 @@ def _build_provider_options(
         temperature: Explicit temperature override
         top_p: Explicit top_p override
         settings_model_params: Model params from settings file
+        settings_tone: Tone the settings file was SAVED with — the settings
+            temperature is tone-coupled and only applies when it matches
+            the effective run tone (the GUI modal persists its Temperature
+            field unconditionally, so a stock 0.5 saved under tone=standard
+            must not pin contextual/pornify to 0.5 forever)
 
     Returns:
         Dict of provider options
@@ -161,9 +167,11 @@ def _build_provider_options(
     result_temp = default_temperature
     result_top_p = default_top_p
 
-    # Apply settings overrides
+    # Apply settings overrides (temperature only when the settings file was
+    # saved for the same tone this run uses — see settings_tone docstring)
     if settings_model_params:
-        if settings_model_params.get('temperature') is not None:
+        if (settings_model_params.get('temperature') is not None
+                and (settings_tone or 'standard') == tone):
             try:
                 result_temp = float(settings_model_params['temperature'])
             except (ValueError, TypeError):
@@ -322,7 +330,8 @@ def translate_with_config(
         tone=tone,
         temperature=temperature,
         top_p=top_p,
-        settings_model_params=settings.get('model_params')
+        settings_model_params=settings.get('model_params'),
+        settings_tone=settings.get('tone')
     )
 
     # Generate output path if not specified
@@ -392,7 +401,16 @@ def translate_with_config(
             if ollama_max_tokens is not None:
                 max_tokens = ollama_max_tokens
 
-            if temperature is None and readiness.get('temperature'):
+            # Curated Ollama temperature replaces only the generic standard-
+            # tone default — contextual's 0.8 and pornify's 1.2 are
+            # intentional tone-tuned values (mirror of cli.py's guard).
+            _settings_temp_applies = (
+                bool((settings.get('model_params') or {}).get('temperature'))
+                and (settings.get('tone') or 'standard') == tone
+            )
+            if (temperature is None and not _settings_temp_applies
+                    and tone not in ('pornify', 'contextual')
+                    and readiness.get('temperature')):
                 provider_options['temperature'] = readiness['temperature']
             provider_options['num_ctx'] = n_ctx
 

--- a/whisperjav/translate/service.py
+++ b/whisperjav/translate/service.py
@@ -148,6 +148,12 @@ def _build_provider_options(
     if tone == 'pornify':
         default_temperature = 1.2
         default_top_p = 0.9
+    elif tone == 'contextual':
+        # Adult-when-source-is-adult: warmer than standard for natural porn
+        # phrasing in explicit lines, but cool enough not to freelance on
+        # neutral dialogue (the failure mode pornify@1.2 is prone to).
+        default_temperature = 0.8
+        default_top_p = 0.9
     else:
         default_temperature = 0.5
         default_top_p = 0.9

--- a/whisperjav/webview_gui/assets/app.js
+++ b/whisperjav/webview_gui/assets/app.js
@@ -7226,6 +7226,21 @@ const TranslationSettingsModal = {
         // Test connection button
         document.getElementById('translationTestConnection')?.addEventListener('click', () => this.testConnection());
 
+        // Tone change reflects the tone's default temperature in the modal's
+        // Temperature field. That field is always forwarded to the backend,
+        // so without this the tone-aware defaults in translate/service.py
+        // (_build_provider_options) never applied — the stale field value
+        // silently won. User edits after the tone switch still stick.
+        // Keep this map in sync with _build_provider_options.
+        const toneTemperatureDefaults = { standard: 0.5, contextual: 0.8, pornify: 1.2 };
+        document.getElementById('translationTone')?.addEventListener('change', (e) => {
+            const temp = toneTemperatureDefaults[e.target.value];
+            const tempInput = document.getElementById('translationTemperature');
+            if (temp !== undefined && tempInput) {
+                tempInput.value = temp;
+            }
+        });
+
         // Provider change handler for inline dropdown — route through ProviderUIManager
         document.getElementById('ensembleTranslateProvider')?.addEventListener('change', (e) => {
             ProviderUIManager.onProviderChange(e.target.value, 'ensemble');

--- a/whisperjav/webview_gui/assets/index.html
+++ b/whisperjav/webview_gui/assets/index.html
@@ -943,7 +943,8 @@
                                             <label for="translatorTone" class="form-label">Tone/Style:</label>
                                             <select id="translatorTone" class="form-select">
                                                 <option value="standard" selected>Standard</option>
-                                                <option value="pornify">Adult/Explicit</option>
+                                                <option value="contextual" title="Explicit language only where the original line is explicit — neutral dialogue stays neutral. Local instructions, not overridden by the online gist.">Adult (contextual)</option>
+                                                <option value="pornify" title="Everything explicit — also sexualizes neutral dialogue by design.">Adult/Explicit</option>
                                             </select>
                                         </div>
                                     </div>
@@ -1341,7 +1342,8 @@
                             <label for="translationTone" class="form-label">Tone/Style:</label>
                             <select id="translationTone" class="form-select">
                                 <option value="standard" selected>Standard</option>
-                                <option value="pornify">Adult/Explicit</option>
+                                <option value="contextual" title="Explicit language only where the original line is explicit — neutral dialogue stays neutral. Local instructions, not overridden by the online gist.">Adult (contextual)</option>
+                                <option value="pornify" title="Everything explicit — also sexualizes neutral dialogue by design.">Adult/Explicit</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
## Problem

The `pornify` tone is all-or-nothing: its (gist-driven) instructions explicitly command *"If the original is polite or subtle, make it flirtatious, teasing, or outright dirty"*, and its retry instructions demand *"no vanilla dialogue allowed!"*. The result on real JAV content: interviews, greetings, and plot dialogue all come out pornified, with verbal tics like "baby" on every other line (the prompt's own example translation plants the word, and the tone's temperature 1.2 amplifies it into a habit). `standard`, meanwhile, can feel too tame during the actual scenes.

## Solution: a middle tone — `contextual`

**Match the source line's explicitness:** neutral dialogue stays neutral, suggestive stays suggestive, explicit sex talk still gets full-strength porn language. The instructions encode the JAV escalation arc but tell the model not to run ahead of the original, and include an anti-tic rule (no repeated pet names/filler unless the original contains an endearment, vary phrasing).

- `whisperjav/translate/defaults/contextual.txt` — bundled instructions (same `### prompt / ### instructions / ### retry_instructions` structure as the existing tones). Deliberately **no entry in `DEFAULT_INSTRUCTION_URLS`**, so `get_instruction_content()` falls through to `load_bundled_default()` and the file ships with the package, immune to gist drift.
- `service.py` — tone-aware temperature default **0.8** (between standard 0.5 and pornify 1.2): warm enough for natural explicit phrasing, cool enough not to freelance on neutral lines.
- `cli.py --tone` / `main.py --translate-tone` — new choice.
- GUI — "Adult (contextual)" in both Tone/Style dropdowns (SRT Translate tab + ensemble translation settings) with explanatory tooltips.

## Bonus fix: tone-aware temperature never applied from the GUI

The ensemble translation-settings modal's Temperature field is always forwarded as an explicit override, and explicit params beat tone defaults — so `_build_provider_options`' tone-aware defaults were dead code from the GUI path (pornify effectively always ran at the field's stale 0.5). Selecting a tone now reflects that tone's default temperature into the field; the user can still edit it afterwards and their value wins.

## Notes

Based directly on current `main`, independently mergeable (like #363). Verified: both CLI parsers accept the new choice, the bundled instructions load with no gist URL configured, `_build_provider_options` returns 0.5/0.8/1.2 per tone, `node --check` passes on app.js.
