### PR TITLE
Unified segmenter param routing - eliminate constructor firewall (#323)

### DIFF
--- a/docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md
+++ b/docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md
@@ -1,0 +1,78 @@
+# Unified Segmenter Param Routing (v1.9.0 P0)
+
+Status: IMPLEMENTED (this branch). Default flip to whisperseg in simple modes is
+NOT included — gated on GT acceptance runs (F4/F6, `tools/fw_diagnostic_suite.py`).
+
+## Problem
+
+`LEGACY_PIPELINES` hardcodes `vad: "silero-v3.1"`, so the resolver always emits
+Silero preset values (including the backend-agnostic grouping keys
+`chunk_threshold_s` / `max_group_duration_s`) into `params["vad"]`. When the
+runtime speech segmenter is non-Silero, the CONSTRUCTOR FIREWALL in
+`whisper_pro_asr.py` / `faster_whisper_pro_asr.py` blanks `params["vad"]`
+entirely — losing the grouping params. WhisperSeg then falls back to its 29s
+`max_group_duration_s` default, triggering the Whisper repetition pathology on
+JAV content (F4/F6 catastrophic empty output). `main.py` therefore force-
+downgraded non-Silero segmenters to silero-v3.1 in simple balanced/fidelity
+modes (issue #323).
+
+## Design
+
+One canonical location: **`params["speech_segmenter"]`** carries `backend`,
+backend-specific detection params, and the shared grouping params. Silero-only
+detection params remain in `params["vad"]` (populated only for Silero backends).
+All segmenter consumers read grouping from the merged segmenter config.
+
+Components:
+
+1. **`whisperjav/config/segmenter_resolution.py`** (new) — single source of
+   truth, shared by the legacy resolver and the ensemble path:
+   - `SEGMENTER_TOOL_NAMES` (backend name → YAML tool), formerly
+     `pass_worker._SEGMENTER_TOOL_NAMES`.
+   - `SEGMENTER_PARAM_KEYS`, formerly `pass_worker.SEGMENTER_PARAMS`.
+   - `GROUPING_KEYS = {"chunk_threshold_s", "max_group_duration_s"}`.
+   - `resolve_segmenter_config(backend, sensitivity, overrides)` — resolves the
+     backend's YAML tool preset (spec < preset < overrides), formerly
+     `pass_worker.resolve_qwen_sensitivity`.
+
+2. **`SegmenterGroupingOptions`** (`config/schemas/vad.py`) — Pydantic model for
+   the two grouping keys, documenting the split from `SileroVADOptions`.
+
+3. **Resolver** — `resolve_legacy_pipeline(..., speech_segmenter=...)` performs
+   segmenter routing at resolution time:
+   - Silero backend (or unset): grouping keys are MOVED from `params["vad"]` to
+     `params["speech_segmenter"]`; Silero detection keys stay in `params["vad"]`.
+   - Non-Silero backend: `params["vad"]` is emptied at the source (no firewall
+     needed) and `params["speech_segmenter"]` is filled from the backend's own
+     YAML sensitivity preset — same values the ensemble/qwen paths use.
+   - `backend` is recorded in `params["speech_segmenter"]["backend"]`.
+
+4. **`main.py`** — segmenter selection happens BEFORE resolution and is passed
+   into `resolve_legacy_pipeline`. The forced downgrade of explicit non-Silero
+   choices is REMOVED: `--mode balanced --speech-segmenter ten|whisperseg|...`
+   now routes correctly. The scoped default (silero-v3.1 for simple modes)
+   is retained until acceptance runs pass; flipping it is a one-line change.
+
+5. **ASR constructors** — the firewall blanking block is removed. The
+   defense-in-depth merge guard remains: Silero backends merge
+   `{**vad_params, **speech_segmenter_config}`; non-Silero backends use
+   `speech_segmenter_config` alone, so stale Silero params passed via direct
+   module instantiation still cannot contaminate non-Silero backends.
+
+6. **`ensemble/pass_worker.py`** — imports the shared constants/function from
+   `config/segmenter_resolution.py` (`resolve_qwen_sensitivity` kept as alias).
+
+## Compatibility
+
+- CLI knobs (`--vad-threshold`, `--speech-pad-ms`) already dual-route into both
+  `params["vad"]` and `params["speech_segmenter"]` post-resolution — unchanged.
+- Silero backends receive grouping keys via the constructor merge, so behavior
+  for balanced/fidelity + silero is value-identical to v1.8.14.
+- Direct module instantiation without resolver: constructor fallback default
+  (whisperseg) and merge guard behave as before.
+
+## Follow-ups (not in this change)
+
+- Flip simple-mode default silero-v3.1 → whisperseg after F4/F6 GT acceptance.
+- Re-tune aggressive preset for large-v3 (separate P0).
+- Migrate ensemble param routing to the canonical location wholesale.

--- a/tests/config/test_segmenter_routing.py
+++ b/tests/config/test_segmenter_routing.py
@@ -1,0 +1,162 @@
+"""
+Tests for v1.9.0 unified segmenter param routing.
+
+Covers whisperjav/config/segmenter_resolution.py and its integration into
+resolve_legacy_pipeline(). These lock in the fix for issue #323 (WhisperSeg /
+TEN unusable outside --ensemble) and the elimination of the constructor
+firewall pattern.
+
+See docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md.
+"""
+
+import pytest
+
+from whisperjav.config.legacy import resolve_legacy_pipeline
+from whisperjav.config.segmenter_resolution import (
+    GROUPING_KEYS,
+    SEGMENTER_PARAM_KEYS,
+    SEGMENTER_TOOL_NAMES,
+    apply_segmenter_routing,
+    is_silero_backend,
+    resolve_segmenter_config,
+)
+
+
+class TestGroupingKeySplit:
+    """Grouping keys are moved out of params['vad'] into the canonical location."""
+
+    def test_silero_grouping_moved_to_canonical(self):
+        config = resolve_legacy_pipeline("balanced", "balanced", speech_segmenter="silero-v3.1")
+        params = config["params"]
+        for key in GROUPING_KEYS:
+            assert key not in params["vad"], f"{key} must not remain in params['vad']"
+            assert key in params["speech_segmenter"], f"{key} missing from canonical location"
+
+    def test_silero_detection_params_stay_in_vad(self):
+        config = resolve_legacy_pipeline("balanced", "balanced", speech_segmenter="silero-v3.1")
+        vad = config["params"]["vad"]
+        for key in ("threshold", "min_speech_duration_ms", "max_speech_duration_s",
+                    "min_silence_duration_ms", "speech_pad_ms"):
+            assert key in vad, f"Silero detection param {key} missing from params['vad']"
+
+    def test_no_backend_still_moves_grouping(self):
+        """Backward compat: resolver without a segmenter arg still canonicalizes."""
+        config = resolve_legacy_pipeline("balanced", "balanced")
+        params = config["params"]
+        for key in GROUPING_KEYS:
+            assert key not in params["vad"]
+            assert key in params["speech_segmenter"]
+        assert "backend" not in params["speech_segmenter"]
+
+
+class TestNonSileroRouting:
+    """Non-Silero backends get their own YAML preset; params['vad'] is emptied."""
+
+    def test_whisperseg_in_balanced_mode(self):
+        """The #323 fix: whisperseg works in simple balanced mode."""
+        config = resolve_legacy_pipeline("balanced", "aggressive", speech_segmenter="whisperseg")
+        params = config["params"]
+        assert params["vad"] == {}, "params['vad'] must be empty for non-Silero (no firewall needed)"
+        seg = params["speech_segmenter"]
+        assert seg["backend"] == "whisperseg"
+        # Values from whisperseg-speech-segmentation.yaml aggressive preset -
+        # NOT the Silero preset, and NOT the pathological 29s fallback.
+        assert seg["max_group_duration_s"] == 5
+        assert seg["chunk_threshold_s"] == 1.0
+        assert seg["threshold"] == 0.25
+
+    def test_whisperseg_balanced_sensitivity(self):
+        config = resolve_legacy_pipeline("balanced", "balanced", speech_segmenter="whisperseg")
+        seg = config["params"]["speech_segmenter"]
+        # whisperseg YAML spec defaults (balanced preset = spec)
+        assert seg["max_group_duration_s"] == 6
+        assert seg["chunk_threshold_s"] == 1.0
+
+    def test_ten_in_fidelity_mode(self):
+        config = resolve_legacy_pipeline("fidelity", "balanced", speech_segmenter="ten")
+        params = config["params"]
+        assert params["vad"] == {}
+        seg = params["speech_segmenter"]
+        assert seg["backend"] == "ten"
+        assert "max_group_duration_s" in seg
+        assert "hop_size" in seg  # TEN-specific param from its own YAML
+
+    def test_none_backend(self):
+        config = resolve_legacy_pipeline("balanced", "balanced", speech_segmenter="none")
+        assert config["params"]["speech_segmenter"]["backend"] == "none"
+
+
+class TestConstructorMergeGuard:
+    """The defense-in-depth merge guard semantics (mirrors ASR constructors)."""
+
+    @staticmethod
+    def _merge(params):
+        vad_params = params["vad"]
+        ssc = params.get("speech_segmenter", {})
+        backend = ssc.get("backend", "whisperseg")
+        if backend.startswith("silero"):
+            return {**vad_params, **ssc}
+        return dict(ssc)
+
+    def test_silero_backend_receives_detection_and_grouping(self):
+        config = resolve_legacy_pipeline("balanced", "balanced", speech_segmenter="silero-v3.1")
+        merged = self._merge(config["params"])
+        assert merged["threshold"] == config["params"]["vad"]["threshold"]
+        assert merged["chunk_threshold_s"] == 2.5
+
+    def test_stale_silero_params_cannot_contaminate_non_silero(self):
+        """Direct instantiation with legacy params: guard still protects."""
+        merged = self._merge({
+            "vad": {"threshold": 0.068, "chunk_threshold_s": 2.5},
+            "speech_segmenter": {"backend": "ten", "max_group_duration_s": 6},
+        })
+        assert "threshold" not in merged
+        assert merged["max_group_duration_s"] == 6
+
+
+class TestSharedDefinitions:
+    """pass_worker must share the canonical definitions (no drift)."""
+
+    def test_pass_worker_imports_shared_constants(self):
+        # pass_worker transitively imports ASR deps; skip in minimal envs
+        pytest.importorskip("stable_whisper")
+        from whisperjav.ensemble import pass_worker
+        assert pass_worker.SEGMENTER_PARAMS is SEGMENTER_PARAM_KEYS
+        assert pass_worker._SEGMENTER_TOOL_NAMES is SEGMENTER_TOOL_NAMES
+
+    def test_grouping_keys_subset_of_segmenter_params(self):
+        assert GROUPING_KEYS <= SEGMENTER_PARAM_KEYS
+
+    def test_all_backends_have_tool_mapping(self):
+        for backend in ("whisperseg", "ten", "nemo", "silero-v3.1", "whisper-vad"):
+            assert backend in SEGMENTER_TOOL_NAMES
+
+
+class TestHelpers:
+    def test_is_silero_backend(self):
+        assert is_silero_backend("silero-v3.1")
+        assert is_silero_backend("silero")
+        assert not is_silero_backend("whisperseg")
+        assert not is_silero_backend("none")
+        assert not is_silero_backend(None)
+        assert not is_silero_backend("")
+
+    def test_resolve_segmenter_config_none(self):
+        assert resolve_segmenter_config("none", "balanced") == {}
+        assert resolve_segmenter_config("", "balanced") == {}
+
+    def test_resolve_segmenter_config_overrides_win(self):
+        cfg = resolve_segmenter_config("whisperseg", "balanced",
+                                       {"max_group_duration_s": 9.5})
+        assert cfg["max_group_duration_s"] == 9.5
+
+    def test_apply_segmenter_routing_user_override_survives(self):
+        """Explicit user values in speech_segmenter beat the backend preset."""
+        params = {
+            "vad": {"threshold": 0.2, "chunk_threshold_s": 2.5},
+            "speech_segmenter": {"max_group_duration_s": 12.0},
+        }
+        apply_segmenter_routing(params, "whisperseg", "balanced")
+        assert params["vad"] == {}
+        assert params["speech_segmenter"]["max_group_duration_s"] == 12.0
+        assert params["speech_segmenter"]["backend"] == "whisperseg"

--- a/whisperjav/config/legacy.py
+++ b/whisperjav/config/legacy.py
@@ -49,6 +49,7 @@ for backward compatibility.
 from typing import Any, Dict, List, Optional
 
 from .resolver_v3 import resolve_config_v3
+from .segmenter_resolution import apply_segmenter_routing
 
 
 def _filter_none_values(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -147,6 +148,7 @@ def resolve_legacy_pipeline(
     overrides: Optional[Dict[str, Any]] = None,
     device: Optional[str] = None,
     compute_type: Optional[str] = None,
+    speech_segmenter: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Resolve configuration from legacy pipeline name.
@@ -197,7 +199,15 @@ def resolve_legacy_pipeline(
         return config
 
     # Map to old output structure for backward compatibility
-    return _map_to_legacy_structure(config, pipeline_def)
+    legacy_config = _map_to_legacy_structure(config, pipeline_def)
+
+    # v1.9.0 unified segmenter routing: place grouping params in the canonical
+    # location (params['speech_segmenter']) and, for non-Silero backends,
+    # resolve the backend's own sensitivity preset instead of shipping
+    # Silero-resolved values that the constructors then had to firewall away.
+    apply_segmenter_routing(legacy_config["params"], speech_segmenter, sensitivity)
+
+    return legacy_config
 
 
 def _map_to_legacy_structure(config: Dict[str, Any], pipeline_def: Dict[str, Any]) -> Dict[str, Any]:

--- a/whisperjav/config/schemas/__init__.py
+++ b/whisperjav/config/schemas/__init__.py
@@ -22,7 +22,7 @@ from .model import MODELS, VAD_ENGINES, ModelConfig, VADEngineConfig
 from .pipeline import ResolvedConfig, ResolvedParams, WorkflowConfig
 from .transcriber import TranscriberOptions
 from .ui import UIPreferences
-from .vad import FasterWhisperVADOptions, SileroVADOptions, StableTSVADOptions
+from .vad import FasterWhisperVADOptions, SegmenterGroupingOptions, SileroVADOptions, StableTSVADOptions
 from .presets import (
     DECODER_PRESETS,
     FASTER_WHISPER_ENGINE_PRESETS,
@@ -53,6 +53,7 @@ __all__ = [
     "DecoderOptions",
     # VAD schemas
     "SileroVADOptions",
+    "SegmenterGroupingOptions",
     "FasterWhisperVADOptions",
     "StableTSVADOptions",
     # Engine schemas

--- a/whisperjav/config/schemas/vad.py
+++ b/whisperjav/config/schemas/vad.py
@@ -40,6 +40,28 @@ class SileroVADOptions(BaseConfig):
     )
 
 
+class SegmenterGroupingOptions(BaseConfig):
+    """
+    Backend-agnostic segment grouping parameters (v1.9.0 split).
+
+    These apply to ALL speech-segmenter backends (Silero, WhisperSeg, TEN,
+    NeMo, Whisper-VAD) and live in the canonical params["speech_segmenter"]
+    location, NOT in params["vad"] (which is Silero-specific).
+    See docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md.
+    """
+
+    chunk_threshold_s: float = Field(
+        ge=0.0, le=30.0,
+        description="Gap threshold for segment grouping (seconds). Segments "
+                    "with gaps larger than this are split into separate groups."
+    )
+    max_group_duration_s: float = Field(
+        ge=1.0, le=60.0,
+        description="Maximum duration for a segment group (seconds). Groups "
+                    "are split if adding a segment would exceed this limit."
+    )
+
+
 class FasterWhisperVADOptions(BaseConfig):
     """
     Faster-Whisper integrated VAD parameters.

--- a/whisperjav/config/segmenter_resolution.py
+++ b/whisperjav/config/segmenter_resolution.py
@@ -1,0 +1,166 @@
+"""
+Canonical speech-segmenter parameter resolution (v1.9.0).
+
+Single source of truth for routing segmenter parameters, shared by the legacy
+resolver (`config/legacy.py`) and the ensemble path (`ensemble/pass_worker.py`).
+
+Canonical location: ``params["speech_segmenter"]`` carries the runtime
+``backend`` name, backend-specific detection params, and the backend-agnostic
+grouping params (``chunk_threshold_s``, ``max_group_duration_s``). Silero-only
+detection params live in ``params["vad"]`` and are merged into the segmenter
+config by ASR constructors for Silero backends only.
+
+See docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md.
+"""
+
+from typing import Any
+
+from whisperjav.utils.logger import logger
+
+# Backend name -> YAML tool name mapping for ConfigManager.get_tool_config().
+# (Moved from ensemble/pass_worker.py in v1.9.0; keep the two in sync via import.)
+SEGMENTER_TOOL_NAMES: dict[str, str] = {
+    "silero-v6.2": "silero-v6-speech-segmentation",
+    "silero": "silero-speech-segmentation",
+    "silero-v4.0": "silero-speech-segmentation",
+    "silero-v3.1": "silero-speech-segmentation",
+    "ten": "ten-speech-segmentation",
+    "nemo": "nemo-speech-segmentation",
+    "nemo-lite": "nemo-speech-segmentation",
+    "whisper-vad": "whisper-vad-speech-segmentation",
+    "whisper-vad-tiny": "whisper-vad-speech-segmentation",
+    "whisper-vad-base": "whisper-vad-speech-segmentation",
+    "whisper-vad-small": "whisper-vad-speech-segmentation",
+    "whisper-vad-medium": "whisper-vad-speech-segmentation",
+    "whisperseg": "whisperseg-speech-segmentation",
+}
+
+# Segmenter params - routed to speech segmentation backends, not to Whisper ASR.
+# Covers all backends: Silero, TEN, Whisper VAD, WhisperSeg, NeMo.
+SEGMENTER_PARAM_KEYS = {
+    # Core VAD (Silero, shared)
+    "threshold",
+    "min_speech_duration_ms",
+    "max_speech_duration_s",
+    "min_silence_duration_ms",
+    "speech_pad_ms",
+    # Grouping (shared across backends)
+    "chunk_threshold_s",
+    "max_group_duration_s",
+    # TEN-specific
+    "hop_size",
+    "start_pad_ms",
+    "end_pad_ms",
+    # Whisper VAD-specific
+    "cache_results",
+}
+
+# Backend-agnostic grouping params (the SegmenterGroupingOptions split).
+GROUPING_KEYS = {"chunk_threshold_s", "max_group_duration_s"}
+
+
+def is_silero_backend(backend: str | None) -> bool:
+    """True if the runtime segmenter backend is a Silero variant."""
+    return bool(backend) and backend.startswith("silero")
+
+
+def resolve_segmenter_config(
+    segmenter_backend: str,
+    sensitivity: str,
+    user_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Resolve a segmenter backend's sensitivity preset into a config dict.
+
+    Layering: backend YAML spec < sensitivity preset < user overrides.
+    Uses ConfigManager.get_tool_config() which implements this exact layering.
+
+    Args:
+        segmenter_backend: Backend name (e.g., "whisperseg", "ten", "silero-v3.1")
+        sensitivity: "aggressive", "balanced", or "conservative"
+        user_overrides: Optional user custom params (win over preset)
+
+    Returns:
+        Dict of segmenter config params (filtered to SEGMENTER_PARAM_KEYS).
+        Empty dict for "none"/empty backend.
+    """
+    if segmenter_backend == "none" or not segmenter_backend:
+        return {}
+
+    tool_name = SEGMENTER_TOOL_NAMES.get(segmenter_backend)
+    if not tool_name:
+        logger.warning(
+            "Unknown segmenter backend '%s' for sensitivity resolution; "
+            "passing user overrides only",
+            segmenter_backend,
+        )
+        return {k: v for k, v in (user_overrides or {}).items() if k in SEGMENTER_PARAM_KEYS}
+
+    try:
+        from whisperjav.config.v4 import ConfigManager
+
+        cm = ConfigManager()
+        resolved = cm.get_tool_config(tool_name, sensitivity, user_overrides)
+
+        # Filter to SEGMENTER_PARAM_KEYS only - ConfigManager returns full tool
+        # config including metadata keys we don't want to pass to the backend.
+        return {k: v for k, v in resolved.items() if k in SEGMENTER_PARAM_KEYS}
+    except Exception as e:
+        logger.warning(
+            "ConfigManager failed for '%s' sensitivity '%s': %s. "
+            "Falling back to user overrides only.",
+            tool_name, sensitivity, e,
+        )
+        return {k: v for k, v in (user_overrides or {}).items() if k in SEGMENTER_PARAM_KEYS}
+
+
+def apply_segmenter_routing(
+    params: dict[str, Any],
+    segmenter_backend: str | None,
+    sensitivity: str,
+) -> dict[str, Any]:
+    """
+    Route segmenter params to their canonical location at resolution time.
+
+    Mutates and returns ``params`` (the resolved config's params dict with
+    ``vad`` and optionally ``speech_segmenter`` sections):
+
+    - Grouping keys are MOVED from params["vad"] to params["speech_segmenter"]
+      (canonical location all consumers read from).
+    - Silero backend (or unset backend): Silero detection params stay in
+      params["vad"]; constructors merge vad + speech_segmenter for Silero.
+    - Non-Silero backend: params["vad"] is emptied at the source (replaces the
+      constructor firewall) and params["speech_segmenter"] is filled from the
+      backend's own YAML sensitivity preset.
+    - If ``segmenter_backend`` is provided, it is recorded in
+      params["speech_segmenter"]["backend"].
+    """
+    vad_params = params.get("vad") or {}
+    segmenter_config = params.get("speech_segmenter") or {}
+
+    if segmenter_backend and not is_silero_backend(segmenter_backend) \
+            and segmenter_backend != "none":
+        # Non-Silero: Silero-resolved values (detection AND grouping) are
+        # meaningless - discard params["vad"] entirely at the source (this
+        # replaces the constructor firewall) and resolve this backend's own
+        # sensitivity preset instead. Values already present in
+        # segmenter_config (explicit user overrides) win over the preset.
+        vad_params = {}
+        preset = resolve_segmenter_config(segmenter_backend, sensitivity)
+        for key, value in preset.items():
+            segmenter_config.setdefault(key, value)
+    else:
+        # Silero backend (or unset): Silero detection params stay in
+        # params["vad"]; move the backend-agnostic grouping keys to the
+        # canonical location. Constructors merge vad + speech_segmenter
+        # for Silero backends, so backends see the same effective values.
+        for key in GROUPING_KEYS:
+            if key in vad_params:
+                segmenter_config.setdefault(key, vad_params.pop(key))
+
+    if segmenter_backend:
+        segmenter_config["backend"] = segmenter_backend
+
+    params["vad"] = vad_params
+    params["speech_segmenter"] = segmenter_config
+    return params

--- a/whisperjav/ensemble/pass_worker.py
+++ b/whisperjav/ensemble/pass_worker.py
@@ -81,43 +81,14 @@ DECODER_PARAMS = {
     "max_initial_timestamp",
 }
 
-# Segmenter params - routed to speech segmentation backends, not passed to Whisper ASR
-# Covers all backends: Silero, TEN, Whisper VAD, and shared grouping params
-SEGMENTER_PARAMS = {
-    # Core VAD (Silero, shared)
-    "threshold",
-    "min_speech_duration_ms",
-    "max_speech_duration_s",   # Keep for CLI backward compat (not in GUI)
-    "min_silence_duration_ms",
-    "speech_pad_ms",
-    # Grouping (shared across backends)
-    "chunk_threshold_s",
-    "max_group_duration_s",
-    # TEN-specific
-    "hop_size",
-    "start_pad_ms",
-    "end_pad_ms",
-    # Whisper VAD-specific
-    "cache_results",
-}
-
-# Backend name → YAML tool name mapping for ConfigManager.get_tool_config()
-# Used by resolve_qwen_sensitivity() to resolve sensitivity presets
-_SEGMENTER_TOOL_NAMES = {
-    "silero-v6.2": "silero-v6-speech-segmentation",
-    "silero": "silero-speech-segmentation",
-    "silero-v4.0": "silero-speech-segmentation",
-    "silero-v3.1": "silero-speech-segmentation",
-    "ten": "ten-speech-segmentation",
-    "nemo": "nemo-speech-segmentation",
-    "nemo-lite": "nemo-speech-segmentation",
-    "whisper-vad": "whisper-vad-speech-segmentation",
-    "whisper-vad-tiny": "whisper-vad-speech-segmentation",
-    "whisper-vad-base": "whisper-vad-speech-segmentation",
-    "whisper-vad-small": "whisper-vad-speech-segmentation",
-    "whisper-vad-medium": "whisper-vad-speech-segmentation",
-    "whisperseg": "whisperseg-speech-segmentation",
-}
+# Segmenter params - routed to speech segmentation backends, not passed to Whisper ASR.
+# v1.9.0: canonical definitions live in config/segmenter_resolution.py (shared
+# with the legacy resolver's unified segmenter routing); imported here to keep
+# the ensemble path and the resolver in sync.
+from whisperjav.config.segmenter_resolution import (
+    SEGMENTER_PARAM_KEYS as SEGMENTER_PARAMS,
+    SEGMENTER_TOOL_NAMES as _SEGMENTER_TOOL_NAMES,  # noqa: F401 (re-export)
+)
 
 # Provider params - common transcriber options shared by all backends
 PROVIDER_PARAMS_COMMON = {
@@ -502,35 +473,14 @@ def resolve_qwen_sensitivity(
 
     Returns:
         Dict of segmenter config params (filtered to SEGMENTER_PARAMS keys)
+
+    .. note:: v1.9.0 - thin alias for the shared implementation in
+       config/segmenter_resolution.py (also used by the legacy resolver's
+       unified segmenter routing).
     """
-    if segmenter_backend == "none" or not segmenter_backend:
-        return {}
+    from whisperjav.config.segmenter_resolution import resolve_segmenter_config
 
-    tool_name = _SEGMENTER_TOOL_NAMES.get(segmenter_backend)
-    if not tool_name:
-        logger.warning(
-            "Unknown segmenter backend '%s' for sensitivity resolution; "
-            "passing user overrides only",
-            segmenter_backend,
-        )
-        return {k: v for k, v in (user_overrides or {}).items() if k in SEGMENTER_PARAMS}
-
-    try:
-        from whisperjav.config.v4 import ConfigManager
-
-        cm = ConfigManager()
-        resolved = cm.get_tool_config(tool_name, sensitivity, user_overrides)
-
-        # Filter to SEGMENTER_PARAMS only — ConfigManager returns full tool config
-        # including metadata keys we don't want to pass to the backend
-        return {k: v for k, v in resolved.items() if k in SEGMENTER_PARAMS}
-    except Exception as e:
-        logger.warning(
-            "ConfigManager failed for '%s' sensitivity '%s': %s. "
-            "Falling back to user overrides only.",
-            tool_name, sensitivity, e,
-        )
-        return {k: v for k, v in (user_overrides or {}).items() if k in SEGMENTER_PARAMS}
+    return resolve_segmenter_config(segmenter_backend, sensitivity, user_overrides)
 
 
 def _write_dropbox_and_exit(result_file: str, result: Dict[str, Any], tracer, exit_code: int) -> None:

--- a/whisperjav/main.py
+++ b/whisperjav/main.py
@@ -1604,6 +1604,44 @@ def process_files_async(media_files: List[Dict], args: argparse.Namespace, resol
             cleanup_temp_directory(args.temp_dir)
 
 
+def _select_speech_segmenter(args):
+    """
+    Select the runtime speech-segmenter backend BEFORE config resolution.
+
+    v1.9.0 unified segmenter routing: the chosen backend is passed into
+    resolve_legacy_pipeline(), which routes segmenter params to the canonical
+    location (params['speech_segmenter']) and resolves the backend's own YAML
+    sensitivity preset for non-Silero backends. Explicit non-Silero choices
+    are now honored in simple balanced/fidelity modes (#323) - the routing
+    bug that forced a silero-v3.1 downgrade is fixed.
+
+    Default policy (unchanged from v1.8.13 pending GT acceptance):
+    - ensemble / decoupled / qwen paths: whisperseg
+    - simple balanced/fidelity: silero-v3.1 (flip to whisperseg after the
+      F4/F6 acceptance runs pass with the fixed routing - one-line change)
+
+    Returns None for modes that don't use a speech segmenter.
+    """
+    mode = getattr(args, 'mode', None)
+
+    # --no-vad disables speech segmentation for balanced/fidelity
+    if getattr(args, 'no_vad', False) and mode in ("balanced", "fidelity"):
+        return "none"
+
+    explicit = getattr(args, 'speech_segmenter', None)
+    if explicit is not None:
+        return explicit
+
+    if getattr(args, 'ensemble', False) or getattr(args, 'pipeline', None) == 'decoupled' \
+            or mode == 'qwen':
+        return "whisperseg"
+
+    if mode in ("balanced", "fidelity"):
+        return "silero-v3.1"
+
+    return None
+
+
 def main():
     """Enhanced main entry point with all V3 improvements."""
     # Apply HuggingFace Hub network resilience patch (#204)
@@ -1764,13 +1802,20 @@ def main():
             logger.debug("Qwen mode: skipping legacy config resolution (uses --qwen-* args)")
 
         else:
-            # Legacy mode: use pipeline resolver
+            # Legacy mode: use pipeline resolver.
+            # v1.9.0 unified segmenter routing: the segmenter backend is
+            # selected BEFORE resolution and passed into the resolver, which
+            # places segmenter params in their canonical location
+            # (params['speech_segmenter']). Non-Silero backends get their own
+            # YAML sensitivity preset - no constructor firewall needed.
+            effective_segmenter = _select_speech_segmenter(args)
             resolved_config = resolve_legacy_pipeline(
                 pipeline_name=args.mode,
                 sensitivity=args.sensitivity,
                 task=task,
                 device=args.device,
                 compute_type=args.compute_type,
+                speech_segmenter=effective_segmenter,
             )
 
         if args.scene_detection_method:
@@ -1837,64 +1882,28 @@ def main():
             resolved_config["params"]["speech_segmenter"]["backend"] = "none"
             logger.info("Speech segmentation disabled via --no-vad flag (backend set to 'none')")
 
-    # Apply --speech-segmenter (explicit override, or v1.8.13 default).
+    # v1.9.0 UNIFIED SEGMENTER ROUTING (see
+    # docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md):
+    # Segmenter selection happens in _select_speech_segmenter() BEFORE config
+    # resolution, and resolve_legacy_pipeline() routes segmenter params to the
+    # canonical location (params['speech_segmenter']) - for non-Silero backends
+    # it resolves the backend's own YAML sensitivity preset and empties
+    # params['vad'] at the source. The v1.8.13 CONSTRUCTOR FIREWALL and the
+    # downgrade guard that force-reverted explicit non-Silero choices to
+    # silero-v3.1 in simple modes are gone: --mode balanced/fidelity with
+    # --speech-segmenter whisperseg/ten/nemo/whisper-vad now routes correctly
+    # without --ensemble (#323).
     #
-    # v1.8.13 ships a SCOPED default flip. Whisperseg becomes the default only on
-    # paths that correctly route segmenter grouping params (chunk_threshold_s,
-    # max_group_duration_s, etc.) to non-Silero backends. Simple --mode balanced
-    # and --mode fidelity go through FasterWhisperProASR / WhisperProASR whose
-    # CONSTRUCTOR FIREWALL strips those params for non-Silero backends, causing
-    # whisperseg to fall back to its 29s default max_group_duration_s and trigger
-    # a Whisper repetition pathology on JAV moaning content (catastrophic empty
-    # output — see F4/F6 acceptance tests). Fix is tracked for v1.9.0 (split
-    # SileroVADOptions, introduce SegmenterGroupingOptions, eliminate firewall).
-    # Until then, simple modes default to silero-v3.1 (the v1.8.12 default,
-    # known-good baseline). Users who want whisperseg in v1.8.13 use --ensemble.
-    def _path_safe_for_whisperseg_default(_args):
-        """Paths with explicit segmenter-param routing for non-Silero backends."""
-        if getattr(_args, 'ensemble', False):
-            return True  # pass_worker.py:1404-1418 routes correctly
-        if getattr(_args, 'pipeline', None) == 'decoupled':
-            return True  # DecoupledPipeline kwargs path
-        if getattr(_args, 'mode', None) == 'qwen':
-            return True  # QwenPipeline explicit forwarding (v1.8.12 fix)
-        return False
-
-    speech_segmenter = getattr(args, 'speech_segmenter', None)
-    if speech_segmenter is None and resolved_config is not None:
-        if _path_safe_for_whisperseg_default(args):
-            speech_segmenter = "whisperseg"
-            logger.debug("No --speech-segmenter passed; using v1.8.13 default: whisperseg")
-        else:
-            speech_segmenter = "silero-v3.1"
-            logger.debug(
-                "No --speech-segmenter passed; --mode %s uses silero-v3.1 "
-                "(v1.8.12 default — non-Silero routing for simple modes is a v1.9.0 fix). "
-                "Use --ensemble to enable whisperseg.",
-                getattr(args, 'mode', None)
-            )
-
-    # Guard: explicit non-Silero choice on a path with the routing bug → downgrade with warning.
-    if speech_segmenter is not None and resolved_config is not None:
-        if (not _path_safe_for_whisperseg_default(args)
-                and speech_segmenter != "none"
-                and not speech_segmenter.startswith("silero")):
-            logger.warning(
-                "Speech segmenter '%s' is not supported in --mode %s due to a known "
-                "v1.9.0 routing bug (catastrophic empty output on JAV moaning content). "
-                "Falling back to silero-v3.1. Use --ensemble for full WhisperSeg / TEN / "
-                "NeMo / whisper-vad support.",
-                speech_segmenter, getattr(args, 'mode', None)
-            )
-            speech_segmenter = "silero-v3.1"
-
-    if speech_segmenter is not None and resolved_config is not None:
-        if "params" not in resolved_config:
-            resolved_config["params"] = {}
-        if "speech_segmenter" not in resolved_config["params"]:
-            resolved_config["params"]["speech_segmenter"] = {}
-        resolved_config["params"]["speech_segmenter"]["backend"] = speech_segmenter
-        logger.info(f"Speech segmenter set to: {speech_segmenter}")
+    # NOTE: the SCOPED whisperseg default is retained for now - simple
+    # balanced/fidelity modes still default to silero-v3.1 until whisperseg
+    # passes the F4/F6 GT acceptance runs with the fixed routing. Flipping the
+    # default is a one-line change in _select_speech_segmenter().
+    if resolved_config is not None and not args.ensemble \
+            and args.mode not in ("transformers", "qwen"):
+        backend = (resolved_config.get("params", {})
+                   .get("speech_segmenter", {}).get("backend"))
+        if backend:
+            logger.info(f"Speech segmenter set to: {backend}")
         # Note: Speech Segmenter factory handles "none" backend internally
 
     # Apply CLI quality knobs (--initial-prompt, --vad-threshold, --condition-on-previous-text)
@@ -1948,30 +1957,13 @@ def main():
         import json
         import copy
 
-        # v1.8.13 (#312): Mirror the WhisperProASR firewall
-        # (whisper_pro_asr.py:71-77) in the dump output. The legacy resolver
-        # always emits silero VAD presets because LEGACY_PIPELINES hardcodes
-        # vad="silero". At runtime, those silero params get cleared by the
-        # firewall when a non-silero segmenter is selected — so the dump
-        # was historically misleading (showed silero values for ten/whisperseg/
-        # silero-v6.2 backends). Apply the same firewall here so users see
-        # the runtime-effective config.
+        # v1.9.0 (#312 follow-up): resolved_config is runtime-accurate at the
+        # source now. The unified segmenter routing empties params["vad"] and
+        # resolves the backend's own YAML preset into params["speech_segmenter"]
+        # AT RESOLUTION TIME, so the v1.8.13 firewall-mirroring workaround that
+        # lived here is no longer needed - what the dump shows is exactly what
+        # the ASR constructors receive.
         dump_resolved = copy.deepcopy(resolved_config) if resolved_config else None
-        if dump_resolved is not None and isinstance(dump_resolved, dict):
-            params = dump_resolved.get("params") or {}
-            ss = params.get("speech_segmenter") or {}
-            backend = ss.get("backend") or "silero-v3.1"  # firewall default
-            if backend and not backend.startswith("silero"):
-                cleared_vad = params.pop("vad", None)
-                params["_dump_note"] = (
-                    f"Resolver-produced silero vad_params cleared for non-silero "
-                    f"backend '{backend}' to mirror the runtime firewall "
-                    f"(whisper_pro_asr.py). Actual runtime VAD settings come from "
-                    f"the {backend} YAML preset at sensitivity='{args.sensitivity}'."
-                )
-                if cleared_vad:
-                    params["_dump_cleared_vad"] = cleared_vad
-                dump_resolved["params"] = params
 
         dump_data = {
             "mode": args.mode,

--- a/whisperjav/modules/faster_whisper_pro_asr.py
+++ b/whisperjav/modules/faster_whisper_pro_asr.py
@@ -82,44 +82,33 @@ class FasterWhisperProASR:
         vad_params = params["vad"]
         provider_params = params["provider"]
 
-        # Determine speech segmenter backend FIRST (needed for firewall below)
+        # Determine speech segmenter backend
         speech_segmenter_config = params.get("speech_segmenter", {})
-        # v1.8.13: default flipped silero-v3.1 -> whisperseg to align with
-        # LEGACY_PIPELINES["balanced"]["vad"] = "whisperseg" (resolver-level
-        # default). The fallback only fires when speech_segmenter.backend is
-        # not set (e.g., direct module instantiation bypassing the resolver).
-        # v1.8.12 history: aligned with v3.1 to fix prior silent override to
-        # silero-v4.0 — that alignment is preserved by keeping resolver and
-        # fallback in sync.
+        # The fallback only fires when speech_segmenter.backend is not set
+        # (e.g., direct module instantiation bypassing the resolver).
         segmenter_backend = speech_segmenter_config.get("backend", "whisperseg")
 
-        # --- CONSTRUCTOR FIREWALL ---
-        # The resolver unconditionally produces Silero VAD presets (threshold=0.068,
-        # speech_pad_ms=500, etc.) because LEGACY_PIPELINES hardcodes vad="silero".
-        # When a non-Silero backend is selected downstream, these params are meaningless.
-        # Blanking them here prevents contamination of ALL downstream consumers:
-        # - self.vad_threshold / self.min_speech_duration_ms (logging)
-        # - merged_segmenter_config (merge guard below, now doubly safe)
-        # - self._vad_parameters (faster-whisper VadOptions, dormant but clean)
-        if not segmenter_backend.startswith("silero"):
-            logger.debug(
-                "Non-Silero backend '%s': clearing resolver-produced Silero vad_params "
-                "to prevent contamination (firewall)",
-                segmenter_backend,
-            )
-            vad_params = {}
-
-        # VAD parameters for logging (now clean after firewall for non-Silero)
-        self.vad_threshold = vad_params.get("threshold", 0.28)
-        self.min_speech_duration_ms = vad_params.get("min_speech_duration_ms", 100)
-
-        # Speech Segmenter merge — defense-in-depth guard (firewall already blanked
-        # vad_params for non-Silero, but this guard prevents accidental merge even if
-        # a future code change bypasses the firewall).
+        # v1.9.0 UNIFIED SEGMENTER ROUTING: the resolver now routes segmenter
+        # params to params["speech_segmenter"] (canonical location) and empties
+        # params["vad"] at the source for non-Silero backends, resolving the
+        # backend's own YAML sensitivity preset instead. The v1.8.13
+        # CONSTRUCTOR FIREWALL that blanked vad_params here is gone.
+        # See docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md.
+        #
+        # Speech Segmenter merge - defense-in-depth guard: only Silero backends
+        # may consume params["vad"] values (protects direct instantiation with
+        # stale Silero params from contaminating non-Silero backends; also
+        # keeps self._vad_parameters (faster-whisper VadOptions, dormant) clean).
         if segmenter_backend.startswith("silero"):
             merged_segmenter_config = {**vad_params, **speech_segmenter_config}
         else:
             merged_segmenter_config = dict(speech_segmenter_config)
+            vad_params = {}
+
+        # VAD parameters for logging (read from merged config: canonical
+        # grouping keys live in speech_segmenter, Silero detection in vad)
+        self.vad_threshold = merged_segmenter_config.get("threshold", 0.28)
+        self.min_speech_duration_ms = merged_segmenter_config.get("min_speech_duration_ms", 100)
 
         try:
             self._external_segmenter = SpeechSegmenterFactory.create(

--- a/whisperjav/modules/whisper_pro_asr.py
+++ b/whisperjav/modules/whisper_pro_asr.py
@@ -54,44 +54,34 @@ class WhisperProASR:
         vad_params = params["vad"]
         provider_params = params["provider"]
 
-        # Determine speech segmenter backend FIRST (needed for firewall below)
+        # Determine speech segmenter backend
         speech_segmenter_config = params.get("speech_segmenter", {})
-        # v1.8.13: default flipped silero-v3.1 -> whisperseg to align with
-        # LEGACY_PIPELINES["fidelity"]["vad"] = "whisperseg" (resolver-level
-        # default). The fallback only fires when speech_segmenter.backend is
-        # not set (e.g., direct module instantiation bypassing the resolver).
-        # v1.8.12 history: aligned with v3.1 to fix prior silent override to
-        # silero-v4.0 — that alignment is preserved by keeping resolver and
-        # fallback in sync.
+        # The fallback only fires when speech_segmenter.backend is not set
+        # (e.g., direct module instantiation bypassing the resolver).
         segmenter_backend = speech_segmenter_config.get("backend", "whisperseg")
 
-        # --- CONSTRUCTOR FIREWALL ---
-        # The resolver unconditionally produces Silero VAD presets (threshold=0.068,
-        # speech_pad_ms=500, etc.) because LEGACY_PIPELINES hardcodes vad="silero".
-        # When a non-Silero backend is selected downstream, these params are meaningless.
-        # Blanking them here prevents contamination of ALL downstream consumers:
-        # - self.vad_threshold / self.min_speech_duration_ms (logging)
-        # - merged_segmenter_config (merge guard below, now doubly safe)
-        if not segmenter_backend.startswith("silero"):
-            logger.debug(
-                "Non-Silero backend '%s': clearing resolver-produced Silero vad_params "
-                "to prevent contamination (firewall)",
-                segmenter_backend,
-            )
-            vad_params = {}
-
-        # VAD parameters for logging (now clean after firewall for non-Silero)
-        self.vad_threshold = vad_params.get("threshold", 0.4)
-        self.min_speech_duration_ms = vad_params.get("min_speech_duration_ms", 150)
-        self.vad_chunk_threshold = vad_params.get("chunk_threshold", 4.0)
-
-        # Speech Segmenter merge — defense-in-depth guard (firewall already blanked
-        # vad_params for non-Silero, but this guard prevents accidental merge even if
-        # a future code change bypasses the firewall).
+        # v1.9.0 UNIFIED SEGMENTER ROUTING: the resolver now routes segmenter
+        # params to params["speech_segmenter"] (canonical location) and empties
+        # params["vad"] at the source for non-Silero backends, resolving the
+        # backend's own YAML sensitivity preset instead. The v1.8.13
+        # CONSTRUCTOR FIREWALL that blanked vad_params here is gone.
+        # See docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md.
+        #
+        # Speech Segmenter merge - defense-in-depth guard: only Silero backends
+        # may consume params["vad"] values (protects direct instantiation with
+        # stale Silero params from contaminating non-Silero backends).
         if segmenter_backend.startswith("silero"):
             merged_segmenter_config = {**vad_params, **speech_segmenter_config}
         else:
             merged_segmenter_config = dict(speech_segmenter_config)
+            vad_params = {}
+
+        # VAD parameters for logging (read from merged config: canonical
+        # grouping keys live in speech_segmenter, Silero detection in vad)
+        self.vad_threshold = merged_segmenter_config.get("threshold", 0.4)
+        self.min_speech_duration_ms = merged_segmenter_config.get("min_speech_duration_ms", 150)
+        self.vad_chunk_threshold = merged_segmenter_config.get(
+            "chunk_threshold_s", merged_segmenter_config.get("chunk_threshold", 4.0))
 
         try:
             self._external_segmenter = SpeechSegmenterFactory.create(


### PR DESCRIPTION
Hi - first-time contributor here. This implements the "unified segmenter
param routing" P0 from your v1.9.0 roadmap notes, hopefully close to the
design you sketched. Happy to adjust anything.

**What it does**

- New `whisperjav/config/segmenter_resolution.py`: canonical home for the
  segmenter tool-name map, param keys, and preset resolution (lifted from
  `pass_worker`, which now imports it - no drift between the two paths).
- `resolve_legacy_pipeline()` gains a `speech_segmenter` argument and routes
  segmenter params to `params["speech_segmenter"]` at resolution time.
  Grouping keys (`chunk_threshold_s`, `max_group_duration_s`) move out of
  `params["vad"]`; a new `SegmenterGroupingOptions` schema documents the split.
- Non-Silero backends resolve their own YAML sensitivity preset instead of
  receiving blanked config - e.g. `--mode balanced --speech-segmenter
  whisperseg` now gets max_group 5-6s from whisperseg's own YAML rather than
  falling back to the pathological 29s default (the F4/F6 mechanism).
- The constructor firewall in `whisper_pro_asr.py` / `faster_whisper_pro_asr.py`
  is removed (the defense-in-depth merge guard stays), and the forced
  silero-v3.1 downgrade for explicit non-Silero choices in simple modes is
  gone (#323). Also removes the now-stale v1.8.13 dump-params firewall
  mirroring (#312 follow-up).

**Deliberately NOT included:** flipping the simple-mode default to
whisperseg - per your roadmap that's gated on F4/F6 GT acceptance runs.
It's a one-line change in `_select_speech_segmenter()` when you're ready.

**Testing:** 16 new tests in `tests/config/test_segmenter_routing.py`;
silero-path values are byte-identical to v1.8.14. Caveat: I don't have a
GPU environment, so I'd suggest one balanced + one `--speech-segmenter
whisperseg` run on real content before merging. Design notes in
`docs/architecture/SEGMENTER_ROUTING_UNIFICATION_v1.9.md`.