### PR TITLE
Green the config test suite (26 stale expectations) + blocking CI workflow

### DIFF
--- a/.github/workflows/accuracy-gate.yml
+++ b/.github/workflows/accuracy-gate.yml
@@ -44,10 +44,14 @@ jobs:
         run: pip install pydantic pyyaml pysrt numpy pytest
 
       - name: Accuracy-gate scorer tests
-        run: python -m pytest tests/bench -q
+        # Ships in the accuracy-gate PR; guard until merged
+        run: |
+          if [ -d tests/bench ]; then python -m pytest tests/bench -q; else echo "tests/bench not present - skipping"; fi
 
       - name: Segmenter routing tests
-        run: python -m pytest tests/config/test_segmenter_routing.py -q
+        # Ships in the unified-routing PR; guard until merged
+        run: |
+          if [ -f tests/config/test_segmenter_routing.py ]; then python -m pytest tests/config/test_segmenter_routing.py -q; else echo "not present - skipping"; fi
 
       # Greened in v1.9.0 (26 stale expectations retuned to current intended
       # values, with provenance comments). BLOCKING: a failure here means a
@@ -57,6 +61,7 @@ jobs:
         run: python -m pytest tests/config -q
 
       - name: Gate smoke test (synthetic corpus)
+        if: ${{ hashFiles('whisperjav/bench/regression_cli.py') != '' }}
         run: |
           python - <<'PY'
           import json, subprocess, sys

--- a/.github/workflows/accuracy-gate.yml
+++ b/.github/workflows/accuracy-gate.yml
@@ -1,0 +1,86 @@
+# Accuracy-gate CI: CPU-only checks that run on every PR.
+#
+# What runs here:
+#   - config-resolution test suite (catches routing/preset plumbing bugs
+#     like the v1.9.0 segmenter firewall issue and YAML/Pydantic drift)
+#   - accuracy-gate scorer unit tests (synthetic regression signatures)
+#
+# What does NOT run here: actual ASR on the GT corpus (needs a GPU).
+# Before releases, run the corpus locally and gate with:
+#   python -m whisperjav.bench.regression_cli gate \
+#       --manifest bench/corpus.yaml --hyp-dir out/candidate \
+#       --baseline bench/baselines/<pipeline>.json \
+#       --thresholds bench/thresholds.yaml
+# If candidate outputs are uploaded as workflow artifacts, the same command
+# gates them here unchanged.
+name: accuracy-gate
+
+on:
+  pull_request:
+    paths:
+      - "whisperjav/config/**"
+      - "whisperjav/bench/**"
+      - "whisperjav/modules/**"
+      - "whisperjav/pipelines/**"
+      - "whisperjav/ensemble/**"
+      - "whisperjav/main.py"
+      - "tests/**"
+      - ".github/workflows/accuracy-gate.yml"
+  push:
+    branches: [main]
+
+jobs:
+  scorer-and-config-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install minimal test dependencies
+        run: pip install pydantic pyyaml pysrt numpy pytest
+
+      - name: Accuracy-gate scorer tests
+        run: python -m pytest tests/bench -q
+
+      - name: Segmenter routing tests
+        run: python -m pytest tests/config/test_segmenter_routing.py -q
+
+      # Greened in v1.9.0 (26 stale expectations retuned to current intended
+      # values, with provenance comments). BLOCKING: a failure here means a
+      # resolved config value changed without a matching test/release-note
+      # update.
+      - name: Config resolution suite
+        run: python -m pytest tests/config -q
+
+      - name: Gate smoke test (synthetic corpus)
+        run: |
+          python - <<'PY'
+          import json, subprocess, sys
+          from pathlib import Path
+
+          def ts(sec):
+              ms = int(round(sec * 1000))
+              return f"{ms//3600000:02d}:{ms%3600000//60000:02d}:{ms%60000//1000:02d},{ms%1000:03d}"
+
+          gt = [(0.0, 2.0, "A"), (3.0, 5.0, "B"), (6.0, 8.5, "C"), (10.0, 12.0, "D")]
+          def srt(entries):
+              return "\n".join(f"{i+1}\n{ts(a)} --> {ts(b)}\n{t}\n" for i, (a, b, t) in enumerate(entries))
+
+          root = Path("gate_smoke"); (root / "gt").mkdir(parents=True); (root / "good").mkdir(); (root / "bad").mkdir()
+          (root / "gt" / "c.srt").write_text(srt(gt))
+          (root / "good" / "c.srt").write_text(srt(gt))
+          (root / "bad" / "c.srt").write_text(srt(gt[:1]))
+          (root / "corpus.yaml").write_text("schema_version: 1\nclips:\n  - id: c\n    media: m\n    ground_truth: gt/c.srt\n")
+
+          def run(*args):
+              return subprocess.run([sys.executable, "-m", "whisperjav.bench.regression_cli", *args]).returncode
+
+          assert run("baseline", "--manifest", str(root/"corpus.yaml"), "--hyp-dir", str(root/"good"), "-o", str(root/"base.json")) == 0
+          assert run("gate", "--manifest", str(root/"corpus.yaml"), "--hyp-dir", str(root/"good"), "--baseline", str(root/"base.json")) == 0, "good run must pass"
+          assert run("gate", "--manifest", str(root/"corpus.yaml"), "--hyp-dir", str(root/"bad"), "--baseline", str(root/"base.json")) == 1, "collapsed run must fail"
+          print("gate smoke OK")
+          PY

--- a/tests/config/test_legacy.py
+++ b/tests/config/test_legacy.py
@@ -96,7 +96,8 @@ class TestBalancedPipeline:
         """Test balanced has silero VAD."""
         config = resolve_legacy_pipeline("balanced")
 
-        assert config['workflow']['vad'] == 'silero'
+        # v1.8.12: pipeline definition pins the versioned component
+        assert config['workflow']['vad'] == 'silero-v3.1'
         assert config['params']['vad'] != {}
 
     def test_has_scene_detection(self):
@@ -178,7 +179,7 @@ class TestHelperFunctions:
 
         assert info['name'] == 'balanced'
         assert info['asr'] == 'faster_whisper'
-        assert info['vad'] == 'silero'
+        assert info['vad'] == 'silero-v3.1'  # v1.8.12
         assert 'description' in info
 
 

--- a/tests/config/test_presets.py
+++ b/tests/config/test_presets.py
@@ -1,11 +1,22 @@
 """
-Tests for presets - verify values match asr_config.json.
+Tests for presets - pin the CURRENT intended sensitivity values.
+
+HISTORY: this file originally verified Pydantic presets against the legacy
+sections of asr_config.json. Those sections were removed in the v1.8.9
+config cleanup (asr_config.json now only carries ui_preferences), which
+left every comparison raising KeyError. As of v1.9.0 the Pydantic presets
+in whisperjav/config/schemas/presets.py ARE the source of truth, so these
+tests pin the intended values inline instead.
+
+Value provenance (update the pins ONLY with a matching release-note entry):
+- v1.8.10-hf2: logprob_threshold -0.75 -> -1.00, logprob_margin 0.2 -> 0.0
+- v1.8.10-hf3: silero thresholds 0.18/0.35/0.05 -> 0.28/0.41/0.18;
+  best_of 1 -> 2, patience 2.0 -> 1.6 (balanced pipeline mapping)
+- v1.8.12:     silero max_speech/max_group tightened (components registry)
+- C1 fix:      hallucination_silence_threshold None = disabled, no fallback
+- CL1b:        balanced temperature [0.0]
 """
 
-import json
-from pathlib import Path
-
-import pytest
 
 from whisperjav.config.schemas import (
     DECODER_PRESETS,
@@ -24,263 +35,212 @@ from whisperjav.config.schemas import (
 )
 
 
-@pytest.fixture
-def asr_config():
-    """Load asr_config.json for comparison."""
-    config_path = Path(__file__).parent.parent.parent / "whisperjav" / "config" / "asr_config.json"
-    with open(config_path) as f:
-        return json.load(f)
-
-
 class TestTranscriberPresets:
-    """Test TranscriberOptions presets match asr_config.json."""
+    """Pin TranscriberOptions preset values."""
 
-    def test_balanced_values(self, asr_config):
-        """Test balanced preset matches JSON."""
+    def test_balanced_values(self):
         preset = TRANSCRIBER_PRESETS[Sensitivity.BALANCED]
-        json_values = asr_config["common_transcriber_options"]["balanced"]
+        assert preset.temperature == [0.0]                     # CL1b
+        assert preset.compression_ratio_threshold == 2.4
+        assert preset.logprob_threshold == -1.0                # v1.8.10-hf2
+        assert preset.logprob_margin == 0.0                    # v1.8.10-hf2
+        assert preset.no_speech_threshold == 0.65              # v1.8.10-hf3
+        assert preset.condition_on_previous_text is False
+        assert preset.word_timestamps is True
 
-        assert preset.temperature == json_values["temperature"]
-        assert preset.compression_ratio_threshold == json_values["compression_ratio_threshold"]
-        assert preset.logprob_threshold == json_values["logprob_threshold"]
-        assert preset.no_speech_threshold == json_values["no_speech_threshold"]
-        assert preset.word_timestamps == json_values["word_timestamps"]
-
-    def test_conservative_values(self, asr_config):
-        """Test conservative preset matches JSON."""
+    def test_conservative_values(self):
         preset = TRANSCRIBER_PRESETS[Sensitivity.CONSERVATIVE]
-        json_values = asr_config["common_transcriber_options"]["conservative"]
+        assert preset.temperature == [0.0]
+        assert preset.compression_ratio_threshold == 2.2
+        assert preset.logprob_threshold == -0.84
+        assert preset.no_speech_threshold == 0.54
 
-        assert preset.temperature == json_values["temperature"]
-        assert preset.no_speech_threshold == json_values["no_speech_threshold"]
-        assert preset.logprob_threshold == json_values["logprob_threshold"]
-
-    def test_aggressive_values(self, asr_config):
-        """Test aggressive preset matches JSON."""
+    def test_aggressive_values(self):
         preset = TRANSCRIBER_PRESETS[Sensitivity.AGGRESSIVE]
-        json_values = asr_config["common_transcriber_options"]["aggressive"]
-
-        assert preset.temperature == json_values["temperature"]
-        assert preset.compression_ratio_threshold == json_values["compression_ratio_threshold"]
-        assert preset.no_speech_threshold == json_values["no_speech_threshold"]
-
-    def test_getter_function(self):
-        """Test get_transcriber_preset returns correct preset."""
-        preset = get_transcriber_preset(Sensitivity.AGGRESSIVE)
-        assert preset == TRANSCRIBER_PRESETS[Sensitivity.AGGRESSIVE]
+        assert preset.temperature == [0.0, 0.2]
+        assert preset.compression_ratio_threshold == 2.6
+        assert preset.logprob_threshold == -1.0
+        assert preset.no_speech_threshold == 0.72
 
 
 class TestDecoderPresets:
-    """Test DecoderOptions presets match asr_config.json."""
+    """Pin DecoderOptions preset values."""
 
-    def test_balanced_values(self, asr_config):
-        """Test balanced preset matches JSON."""
+    def test_balanced_values(self):
         preset = DECODER_PRESETS[Sensitivity.BALANCED]
-        json_values = asr_config["common_decoder_options"]["balanced"]
+        assert preset.task == "transcribe"
+        assert preset.language == "ja"
+        assert preset.beam_size == 2
+        assert preset.best_of == 2                             # v1.8.10-hf3
+        assert preset.patience == 1.2
+        assert preset.suppress_blank is True
+        # None -> whisper library default applies (dropped on export)
+        assert preset.suppress_tokens is None
 
-        assert preset.beam_size == json_values["beam_size"]
-        assert preset.patience == json_values["patience"]
-        assert preset.suppress_blank == json_values["suppress_blank"]
-
-    def test_conservative_values(self, asr_config):
-        """Test conservative preset matches JSON."""
+    def test_conservative_values(self):
         preset = DECODER_PRESETS[Sensitivity.CONSERVATIVE]
-        json_values = asr_config["common_decoder_options"]["conservative"]
+        assert preset.beam_size == 2
+        assert preset.best_of == 2
+        assert preset.patience == 1.0
 
-        assert preset.beam_size == json_values["beam_size"]
-        assert preset.patience == json_values["patience"]
-
-    def test_aggressive_values(self, asr_config):
-        """Test aggressive preset matches JSON."""
+    def test_aggressive_values(self):
         preset = DECODER_PRESETS[Sensitivity.AGGRESSIVE]
-        json_values = asr_config["common_decoder_options"]["aggressive"]
-
-        assert preset.beam_size == json_values["beam_size"]
-        assert preset.patience == json_values["patience"]
-        assert preset.suppress_blank == json_values["suppress_blank"]
-        assert preset.suppress_tokens == json_values["suppress_tokens"]
-
-    def test_getter_function(self):
-        """Test get_decoder_preset returns correct preset."""
-        preset = get_decoder_preset(Sensitivity.BALANCED)
-        assert preset == DECODER_PRESETS[Sensitivity.BALANCED]
+        assert preset.beam_size == 3
+        assert preset.best_of == 2
+        assert preset.patience == 1.3
 
 
 class TestSileroVADPresets:
-    """Test SileroVADOptions presets from v4 YAML configuration."""
+    """Pin Silero VAD preset values (schemas copy)."""
 
-    @pytest.fixture
-    def silero_tool(self):
-        """Load Silero speech segmentation tool from v4 YAML."""
-        from whisperjav.config.v4.registries.tool_registry import get_tool_registry
-        registry = get_tool_registry()
-        return registry.get("silero-speech-segmentation")
+    def test_balanced_values(self):
+        preset = SILERO_VAD_PRESETS[Sensitivity.BALANCED]
+        assert preset.threshold == 0.28                        # v1.8.10-hf3
+        assert preset.min_speech_duration_ms == 100
+        assert preset.max_speech_duration_s == 5.0             # v1.8.12
+        assert preset.min_silence_duration_ms == 300
+        assert preset.speech_pad_ms == 400
 
-    def test_balanced_values(self, silero_tool):
-        """Test balanced preset values from v4 YAML."""
-        # Balanced uses spec defaults
-        spec = silero_tool.spec
+    def test_conservative_values(self):
+        preset = SILERO_VAD_PRESETS[Sensitivity.CONSERVATIVE]
+        assert preset.threshold == 0.41                        # v1.8.10-hf3
+        assert preset.min_speech_duration_ms == 150
+        assert preset.max_speech_duration_s == 6.0
+        assert preset.speech_pad_ms == 500
 
-        assert spec["vad.threshold"] == 0.18
-        assert spec["vad.min_speech_duration_ms"] == 100
-        assert spec["vad.max_speech_duration_s"] == 11.0
-        assert spec["vad.speech_pad_ms"] == 400
+    def test_aggressive_values(self):
+        preset = SILERO_VAD_PRESETS[Sensitivity.AGGRESSIVE]
+        assert preset.threshold == 0.18                        # v1.8.10-hf3
+        assert preset.min_speech_duration_ms == 30
+        assert preset.max_speech_duration_s == 4.0             # v1.8.12
+        assert preset.speech_pad_ms == 300
 
-    def test_conservative_values(self, silero_tool):
-        """Test conservative preset values from v4 YAML."""
-        config = silero_tool.get_resolved_config("conservative")
+    def test_matches_runtime_registry(self):
+        """Guard: the schemas copy must not drift from the runtime registry.
 
-        assert config["vad.threshold"] == 0.35
-        assert config["vad.neg_threshold"] == 0.3
-        assert config["vad.min_speech_duration_ms"] == 150
-        assert config["vad.max_speech_duration_s"] == 9.0
+        resolve_config_v3 reads presets from the components VAD registry
+        (whisperjav/config/components/vad/silero.py), NOT from this schemas
+        copy. Before v1.9.0 the two silently diverged (schemas kept the
+        pre-v1.8.12 max_speech caps). Grouping keys (chunk_threshold_s,
+        max_group_duration_s) exist only in the registry by design - see
+        SegmenterGroupingOptions.
+        """
+        from whisperjav.config.components.base import get_vad_registry
 
-    def test_aggressive_values(self, silero_tool):
-        """Test aggressive preset values from v4 YAML."""
-        config = silero_tool.get_resolved_config("aggressive")
-
-        assert config["vad.threshold"] == 0.05
-        assert config["vad.neg_threshold"] == 0.1
-        assert config["vad.min_speech_duration_ms"] == 30
-        assert config["vad.speech_pad_ms"] == 600
-
-    def test_legacy_getter_function(self):
-        """Test legacy get_silero_vad_preset still works."""
-        # Legacy function still available for backward compatibility
-        preset = get_silero_vad_preset(Sensitivity.CONSERVATIVE)
-        assert preset == SILERO_VAD_PRESETS[Sensitivity.CONSERVATIVE]
-
-    def test_v4_presets_available(self, silero_tool):
-        """Test all expected presets exist in v4 YAML."""
-        assert "conservative" in silero_tool.presets
-        assert "balanced" in silero_tool.presets
-        assert "aggressive" in silero_tool.presets
+        component = get_vad_registry()["silero"]
+        shared_keys = (
+            "threshold", "min_speech_duration_ms", "max_speech_duration_s",
+            "min_silence_duration_ms", "speech_pad_ms",
+        )
+        for sens in Sensitivity:
+            schemas_preset = SILERO_VAD_PRESETS[sens].model_dump()
+            registry_preset = component.get_preset(sens.value).model_dump()
+            for key in shared_keys:
+                assert schemas_preset[key] == registry_preset[key], (
+                    f"schemas/presets.py diverged from components registry: "
+                    f"{sens.value}.{key}: {schemas_preset[key]} != {registry_preset[key]}"
+                )
 
 
 class TestStableTSVADPresets:
-    """Test StableTSVADOptions presets match asr_config.json."""
+    """Pin Stable-TS VAD preset values."""
 
-    def test_balanced_values(self, asr_config):
-        """Test balanced preset matches JSON."""
+    def test_balanced_values(self):
         preset = STABLE_TS_VAD_PRESETS[Sensitivity.BALANCED]
-        json_values = asr_config["stable_ts_vad_options"]["balanced"]
+        assert preset.vad is True
+        assert preset.vad_threshold == 0.25
 
-        assert preset.vad == json_values["vad"]
-        assert preset.vad_threshold == json_values["vad_threshold"]
-
-    def test_conservative_values(self, asr_config):
-        """Test conservative preset matches JSON."""
+    def test_conservative_values(self):
         preset = STABLE_TS_VAD_PRESETS[Sensitivity.CONSERVATIVE]
-        json_values = asr_config["stable_ts_vad_options"]["conservative"]
+        assert preset.vad_threshold == 0.35
 
-        assert preset.vad_threshold == json_values["vad_threshold"]
-
-    def test_aggressive_values(self, asr_config):
-        """Test aggressive preset matches JSON."""
+    def test_aggressive_values(self):
         preset = STABLE_TS_VAD_PRESETS[Sensitivity.AGGRESSIVE]
-        json_values = asr_config["stable_ts_vad_options"]["aggressive"]
-
-        assert preset.vad_threshold == json_values["vad_threshold"]
-
-    def test_getter_function(self):
-        """Test get_stable_ts_vad_preset returns correct preset."""
-        preset = get_stable_ts_vad_preset(Sensitivity.AGGRESSIVE)
-        assert preset == STABLE_TS_VAD_PRESETS[Sensitivity.AGGRESSIVE]
+        assert preset.vad_threshold == 0.1
 
 
 class TestFasterWhisperEnginePresets:
-    """Test FasterWhisperEngineOptions presets match asr_config.json."""
+    """Pin Faster-Whisper engine preset values."""
 
-    def test_balanced_values(self, asr_config):
-        """Test balanced preset matches JSON."""
+    def test_balanced_values(self):
         preset = FASTER_WHISPER_ENGINE_PRESETS[Sensitivity.BALANCED]
-        json_values = asr_config["faster_whisper_engine_options"]["balanced"]
+        assert preset.repetition_penalty == 1.5
+        assert preset.no_repeat_ngram_size == 3                # H1
+        assert preset.multilingual is False
 
-        assert preset.repetition_penalty == json_values["repetition_penalty"]
-        # JSON has 2.0 but we use int 2
-        assert preset.no_repeat_ngram_size == int(json_values["no_repeat_ngram_size"])
-
-    def test_conservative_values(self, asr_config):
-        """Test conservative preset matches JSON."""
+    def test_conservative_values(self):
         preset = FASTER_WHISPER_ENGINE_PRESETS[Sensitivity.CONSERVATIVE]
-        json_values = asr_config["faster_whisper_engine_options"]["conservative"]
+        assert preset.repetition_penalty == 1.8
+        assert preset.no_repeat_ngram_size == 3
 
-        assert preset.repetition_penalty == json_values["repetition_penalty"]
-
-    def test_aggressive_values(self, asr_config):
-        """Test aggressive preset matches JSON."""
+    def test_aggressive_values(self):
         preset = FASTER_WHISPER_ENGINE_PRESETS[Sensitivity.AGGRESSIVE]
-        json_values = asr_config["faster_whisper_engine_options"]["aggressive"]
-
-        assert preset.chunk_length == json_values["chunk_length"]
-        assert preset.repetition_penalty == json_values["repetition_penalty"]
-
-    def test_getter_function(self):
-        """Test get_faster_whisper_engine_preset returns correct preset."""
-        preset = get_faster_whisper_engine_preset(Sensitivity.BALANCED)
-        assert preset == FASTER_WHISPER_ENGINE_PRESETS[Sensitivity.BALANCED]
+        assert preset.repetition_penalty == 1.3
+        assert preset.no_repeat_ngram_size == 3
+        # chunk_length=30 is NOT a bug - empirically confirmed, see
+        # memory/project_v1813_session_lessons.md lesson 1
+        assert preset.chunk_length == 30
 
 
 class TestStableTSEngineOptions:
-    """Test StableTSEngineOptions values match asr_config.json."""
+    """Pin Stable-TS engine option defaults."""
 
-    def test_default_values(self, asr_config):
-        """Test stable-ts engine options match JSON (same across sensitivities)."""
-        json_values = asr_config["stable_ts_engine_options"]["balanced"]
-
-        assert STABLE_TS_ENGINE_OPTIONS.gap_padding == json_values["gap_padding"]
-        assert STABLE_TS_ENGINE_OPTIONS.regroup == json_values["regroup"]
-        assert STABLE_TS_ENGINE_OPTIONS.suppress_silence == json_values["suppress_silence"]
-        assert STABLE_TS_ENGINE_OPTIONS.q_levels == json_values["q_levels"]
-        assert STABLE_TS_ENGINE_OPTIONS.k_size == json_values["k_size"]
+    def test_default_values(self):
+        opts = STABLE_TS_ENGINE_OPTIONS
+        assert opts.gap_padding == " ..."
+        assert opts.max_instant_words == 0.5
+        assert opts.nonspeech_error == 0.1
+        assert opts.ignore_compatibility is True
+        assert opts.regroup is True
+        assert opts.q_levels == 20
+        assert opts.k_size == 5
 
 
 class TestHallucinationThresholds:
-    """Test hallucination threshold values match asr_config.json."""
+    """hallucination_silence_threshold: None = disabled (C1 fix)."""
 
-    def test_values(self, asr_config):
-        """Test hallucination thresholds match JSON."""
-        json_values = asr_config["exclusive_whisper_plus_faster_whisper"]
+    def test_values(self):
+        for sens in Sensitivity:
+            assert HALLUCINATION_THRESHOLDS[sens] is None, (
+                f"C1 fix: hallucination_silence_threshold must be None "
+                f"(disabled) for {sens.value}"
+            )
 
-        assert HALLUCINATION_THRESHOLDS[Sensitivity.BALANCED] == json_values["balanced"]["hallucination_silence_threshold"]
-        assert HALLUCINATION_THRESHOLDS[Sensitivity.CONSERVATIVE] == json_values["conservative"]["hallucination_silence_threshold"]
-        assert HALLUCINATION_THRESHOLDS[Sensitivity.AGGRESSIVE] == json_values["aggressive"]["hallucination_silence_threshold"]
+
+class TestPresetGetters:
+    """Getter functions return the same objects as the dicts."""
+
+    def test_getters_match_dicts(self):
+        for sens in Sensitivity:
+            assert get_transcriber_preset(sens) == TRANSCRIBER_PRESETS[sens]
+            assert get_decoder_preset(sens) == DECODER_PRESETS[sens]
+            assert get_silero_vad_preset(sens) == SILERO_VAD_PRESETS[sens]
+            assert get_stable_ts_vad_preset(sens) == STABLE_TS_VAD_PRESETS[sens]
+            assert get_faster_whisper_engine_preset(sens) == FASTER_WHISPER_ENGINE_PRESETS[sens]
 
 
 class TestPresetExport:
-    """Test presets can be exported without None values."""
+    """Test presets export without None values."""
 
     def test_transcriber_export(self):
-        """Test transcriber preset exports correctly."""
         preset = TRANSCRIBER_PRESETS[Sensitivity.BALANCED]
         result = preset.model_dump_without_none()
-
-        # Should not contain None values
         assert "initial_prompt" not in result
         assert "prepend_punctuations" not in result
-
-        # Should contain actual values
-        assert result["temperature"] == [0.0, 0.1]
+        assert result["temperature"] == [0.0]                  # CL1b
         assert result["word_timestamps"] is True
 
     def test_decoder_export(self):
-        """Test decoder preset exports correctly."""
         preset = DECODER_PRESETS[Sensitivity.AGGRESSIVE]
         result = preset.model_dump_without_none()
-
-        # Should contain empty list, not None
-        assert "suppress_tokens" in result
-        assert result["suppress_tokens"] == []
-
-        # Should not contain None values
+        # suppress_tokens is None -> dropped on export, whisper default applies
+        assert "suppress_tokens" not in result
         assert "length_penalty" not in result
+        assert result["beam_size"] == 3
 
     def test_vad_export(self):
-        """Test VAD preset exports all values."""
         preset = SILERO_VAD_PRESETS[Sensitivity.AGGRESSIVE]
         result = preset.model_dump_without_none()
-
-        # All VAD params are required, so all should be present
-        assert result["threshold"] == 0.05
+        assert result["threshold"] == 0.18                     # v1.8.10-hf3
         assert result["min_speech_duration_ms"] == 30
-        assert result["speech_pad_ms"] == 600
+        assert result["speech_pad_ms"] == 300

--- a/tests/config/test_resolver_v3.py
+++ b/tests/config/test_resolver_v3.py
@@ -93,20 +93,20 @@ class TestSensitivityPresets:
         """Test conservative preset has expected v1 values."""
         config = resolve_config_v3('faster_whisper', 'silero', 'conservative')
 
-        # Conservative: strict thresholds, smallest beam
-        assert config['params']['vad']['threshold'] == 0.35
-        assert config['params']['asr']['beam_size'] == 1
-        assert config['params']['asr']['no_speech_threshold'] == 0.74
+        # Conservative: strict thresholds (v1.8.10-hf3 retune)
+        assert config['params']['vad']['threshold'] == 0.41
+        assert config['params']['asr']['beam_size'] == 2
+        assert config['params']['asr']['no_speech_threshold'] == 0.54
 
     def test_aggressive_values(self):
         """Test aggressive preset has expected values."""
         config = resolve_config_v3('faster_whisper', 'silero', 'aggressive')
 
-        # Aggressive: permissive thresholds, low VAD threshold
-        assert config['params']['vad']['threshold'] == 0.05
-        assert config['params']['asr']['beam_size'] == 2
-        assert config['params']['asr']['no_speech_threshold'] == 0.22
-        assert config['params']['asr']['patience'] == 2.0  # Optimized from 2.9 for better speed
+        # Aggressive: permissive thresholds (v1.8.10-hf3 retune)
+        assert config['params']['vad']['threshold'] == 0.18
+        assert config['params']['asr']['beam_size'] == 3
+        assert config['params']['asr']['no_speech_threshold'] == 0.72
+        assert config['params']['asr']['patience'] == 1.3
 
     def test_presets_differ(self):
         """Test presets produce different values."""

--- a/tests/config/test_schemas_vad_engine.py
+++ b/tests/config/test_schemas_vad_engine.py
@@ -21,12 +21,13 @@ class TestSileroVADOptions:
 
     def test_valid_balanced_preset(self):
         """Test balanced preset values are valid."""
+        # neg_threshold was removed from SileroVADOptions - VAD internal
+        # logic handles it (see components/vad/silero.py preset comments)
         config = SileroVADOptions(
             threshold=0.18,
             min_speech_duration_ms=100,
             max_speech_duration_s=11,
             min_silence_duration_ms=300,
-            neg_threshold=0.15,
             speech_pad_ms=400
         )
         assert config.threshold == 0.18
@@ -39,7 +40,6 @@ class TestSileroVADOptions:
                 min_speech_duration_ms=100,
                 max_speech_duration_s=11,
                 min_silence_duration_ms=300,
-                neg_threshold=0.15,
                 speech_pad_ms=400
             )
 
@@ -276,7 +276,9 @@ class TestJAVAudioConfig:
         adjustments = config.get_vad_adjustments()
 
         assert "min_speech_duration_ms" in adjustments
-        assert "neg_threshold" in adjustments
+        # neg_threshold adjustment removed with the schema field - VAD
+        # internal logic handles negative-threshold behavior now
+        assert "neg_threshold" not in adjustments
 
     def test_invalid_noise_profile(self):
         """Test invalid noise profile is rejected."""

--- a/whisperjav/config/schemas/presets.py
+++ b/whisperjav/config/schemas/presets.py
@@ -122,7 +122,7 @@ SILERO_VAD_PRESETS = {
     Sensitivity.BALANCED: SileroVADOptions(
         threshold=0.28,                       # v1.8.10-hf3: 0.18→0.28
         min_speech_duration_ms=100,
-        max_speech_duration_s=7.0,            # v1.8.10-hf3: 11.0→7.0
+        max_speech_duration_s=5.0,            # v1.8.12: 7.0→5.0, sync with components registry
         min_silence_duration_ms=300,
         speech_pad_ms=400
     ),
@@ -136,7 +136,7 @@ SILERO_VAD_PRESETS = {
     Sensitivity.AGGRESSIVE: SileroVADOptions(
         threshold=0.18,                       # v1.8.10-hf3: 0.05→0.18
         min_speech_duration_ms=30,
-        max_speech_duration_s=8.0,            # v1.8.10-hf3: 14.0→8.0
+        max_speech_duration_s=4.0,            # v1.8.12: 8.0→4.0, sync with components registry
         min_silence_duration_ms=300,
         speech_pad_ms=300
     ),


### PR DESCRIPTION
Third of four related PRs (see #375 for context).

`tests/config` has had 26 permanent failures since the v1.8.9 config
cleanup deleted the asr_config.json sections the tests compared against.
A suite that's always red can't gate anything.

**What it does**

- Rewrites `test_presets.py` to pin current intended values inline, each
  annotated with the release that set it (v1.8.10-hf2/hf3, v1.8.12, C1, CL1b).
- Updates `test_legacy.py` (silero -> silero-v3.1, v1.8.12),
  `test_resolver_v3.py` (v1.8.10-hf3 sensitivity values), and
  `test_schemas_vad_engine.py` (neg_threshold removal).
- **One real bug found and fixed:** the `schemas/presets.py` silero copy
  still carried pre-v1.8.12 max_speech caps (7.0/8.0 vs the runtime
  registry's 5.0/4.0). A new `test_matches_runtime_registry` guard fails
  if the two preset sources ever diverge again - same bug class as the
  YAML/Pydantic sensitivity mismatch noted in the tracker.
- Adds `.github/workflows/accuracy-gate.yml`: a blocking config-suite job
  on every PR (CPU-only, no models downloaded). Steps that reference tests
  from my other PRs are guarded, so this runs green regardless of merge
  order.

**Result:** tests/config is 100% green (241 passing here) and protected
in CI going forward.