### PR TITLE
Ergonomics: skip-existing in GUI/ensemble, opt-in settings persistence, junction-safe saves, DeepSeek v4 dropdowns

### DIFF
--- a/tests/test_gui_settings.py
+++ b/tests/test_gui_settings.py
@@ -816,7 +816,8 @@ class TestCompleteness:
         data_keys = {
             k for k in DEFAULT_GUI_SETTINGS if k not in ("version", "_comment")
         }
-        # 13 Tab 1 keys + 14 Tab 3 keys + 2 preset keys = 29
-        assert len(data_keys) == 29, (
-            f"Expected 29 settings keys, got {len(data_keys)}: {data_keys}"
+        # 15 Tab 1 keys + 14 Tab 3 keys + 2 preset keys = 31
+        # (v1.9.0: +skip_existing, +remember_settings)
+        assert len(data_keys) == 31, (
+            f"Expected 31 settings keys, got {len(data_keys)}: {data_keys}"
         )

--- a/whisperjav/main.py
+++ b/whisperjav/main.py
@@ -2254,6 +2254,29 @@ def main():
                 pass1_config, pass2_config, logger=logger
             )
 
+            # --skip-existing (#328): filter out files whose merged output
+            # already exists. Mirrors the sync/async single-pass behavior;
+            # ensemble's final artifact is <basename>.<lang>.merged.whisperjav.srt.
+            if getattr(args, 'skip_existing', False):
+                _out_lang = 'en' if args.subs_language == 'direct-to-english' else language_code
+                _to_source = str(args.output_dir).lower().strip() == "source"
+                _remaining = []
+                for media_info in media_files:
+                    _src = Path(media_info.get('path', ''))
+                    _base = media_info.get('basename', _src.stem)
+                    _dir = _src.parent if _to_source else Path(args.output_dir)
+                    if (_dir / f"{_base}.{_out_lang}.merged.whisperjav.srt").exists():
+                        logger.info(f"Skipping (merged output exists): {_src.name}")
+                    else:
+                        _remaining.append(media_info)
+                _n_skipped = len(media_files) - len(_remaining)
+                if _n_skipped:
+                    print(f"\nSkipping {_n_skipped} file(s) with existing merged outputs (--skip-existing)")
+                media_files = _remaining
+                if not media_files:
+                    print("All files already have merged outputs - nothing to do.")
+                    sys.exit(0)
+
             # Create orchestrator
             # "source" sentinel is passed through — orchestrator resolves per-file
             ensemble_output_dir = args.output_dir

--- a/whisperjav/settings/gui_settings.py
+++ b/whisperjav/settings/gui_settings.py
@@ -46,6 +46,8 @@ DEFAULT_GUI_SETTINGS = {
     "output_dir": "",
     "debug_logging": False,
     "keep_temp": False,
+    "skip_existing": False,
+    "remember_settings": False,
     "temp_dir": "",
     "accept_cpu_mode": False,
     "async_processing": False,
@@ -79,7 +81,34 @@ def get_gui_settings_path() -> Path:
     else:
         base = Path.home() / ".config"
 
-    return (base / "WhisperJAV" / "gui_settings.json").expanduser()
+    path = (base / "WhisperJAV" / "gui_settings.json").expanduser()
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def atomic_write_json(path, payload, logger_=None) -> None:
+    """Write payload as JSON atomically; fall back to direct write on OSError (#309)."""
+    import json as _json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        _json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.flush()
+        os.fsync(f.fileno())
+    try:
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        if logger_ is not None:
+            logger_.warning("Atomic replace failed for %s (%s); direct write", path, exc)
+        with open(path, "w", encoding="utf-8") as f:
+            _json.dump(payload, f, indent=2, ensure_ascii=False)
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
 
 
 def _rotate_backups(settings_path: Path) -> Optional[Path]:
@@ -224,19 +253,8 @@ def save_gui_settings(settings: dict) -> bool:
         existing["version"] = SETTINGS_SCHEMA_VERSION
         existing["_comment"] = DEFAULT_GUI_SETTINGS["_comment"]
 
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Atomic write: .tmp → rename
-        tmp_path = settings_path.with_suffix(".json.tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            json.dump(existing, f, indent=2, ensure_ascii=False)
-            f.flush()
-            os.fsync(f.fileno())
-
-        # On Windows, rename fails if target exists — remove first
-        if settings_path.exists():
-            settings_path.unlink()
-        tmp_path.rename(settings_path)
+        # Atomic write with junction-safe fallback (#309)
+        atomic_write_json(settings_path, existing, logger_=logger)
 
         logger.debug("GUI settings saved to %s", settings_path)
         return True

--- a/whisperjav/settings/presets.py
+++ b/whisperjav/settings/presets.py
@@ -16,7 +16,6 @@ Each file:  <sanitized-name>.json
 
 import json
 import logging
-import os
 import re
 import time
 from pathlib import Path
@@ -162,17 +161,9 @@ def save_preset(name: str, data: Dict) -> bool:
             else:
                 data["created_at"] = now
 
-        # Atomic write
-        tmp_path = path.with_suffix(".json.tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.flush()
-            os.fsync(f.fileno())
-
-        # Windows: rename fails if target exists
-        if path.exists():
-            path.unlink()
-        tmp_path.rename(path)
+        # Atomic write with junction-safe fallback (#309)
+        from .gui_settings import atomic_write_json
+        atomic_write_json(path, data, logger_=logger)
 
         logger.debug("Preset saved: %s → %s", name, path)
         return True

--- a/whisperjav/webview_gui/api.py
+++ b/whisperjav/webview_gui/api.py
@@ -170,6 +170,9 @@ class WhisperJAVAPI:
         if options.get('keep_temp', False):
             args += ["--keep-temp"]
 
+        if options.get('skip_existing', False):
+            args += ["--skip-existing"]
+
         # Debug logging
         if options.get('debug', False):
             args += ["--debug"]
@@ -278,6 +281,9 @@ class WhisperJAVAPI:
 
         if options.get('keep_temp', False):
             args += ["--keep-temp"]
+
+        if options.get('skip_existing', False):
+            args += ["--skip-existing"]
 
         if options.get('debug', False):
             args += ["--debug"]
@@ -1636,6 +1642,9 @@ class WhisperJAVAPI:
         if options.get('keep_temp', False):
             args += ["--keep-temp"]
 
+        if options.get('skip_existing', False):
+            args += ["--skip-existing"]
+
         # Verbosity
         verbosity = options.get('verbosity', 'summary')
         if verbosity:
@@ -2717,6 +2726,9 @@ class WhisperJAVAPI:
         if config.get('keep_temp', False):
             args += ["--keep-temp"]
 
+        if config.get('skip_existing', False):
+            args += ["--skip-existing"]
+
         # Debug logging
         if config.get('debug', False):
             args += ["--debug"]
@@ -3195,6 +3207,8 @@ class WhisperJAVAPI:
         "debug_logging":             "debugLogging",
         "output_format":             "outputFormat",
         "keep_temp":                 "keepTemp",
+        "skip_existing":             "skipExisting",
+        "remember_settings":         "rememberSettings",
         "temp_dir":                  "tempDir",
         "accept_cpu_mode":           "acceptCpuMode",
         "async_processing":          "asyncProcessing",

--- a/whisperjav/webview_gui/assets/app.js
+++ b/whisperjav/webview_gui/assets/app.js
@@ -704,6 +704,7 @@ const FormManager = {
             subs_language: document.getElementById('language').value,
             debug: document.getElementById('debugLogging').checked,
             keep_temp: document.getElementById('keepTemp').checked,
+            skip_existing: document.getElementById('skipExisting').checked,
             temp_dir: document.getElementById('tempDir').value.trim(),
             accept_cpu_mode: document.getElementById('acceptCpuMode').checked,
             output_format: document.getElementById('outputFormat').value,
@@ -5108,6 +5109,7 @@ const EnsembleManager = {
             subs_language: document.getElementById('language').value,
             debug: document.getElementById('debugLogging').checked,
             keep_temp: document.getElementById('keepTemp').checked,
+            skip_existing: document.getElementById('skipExisting').checked,
             temp_dir: document.getElementById('tempDir').value.trim(),
             output_format: document.getElementById('outputFormat').value,
         };
@@ -6614,7 +6616,9 @@ const TranslatorManager = {
     // Provider model options (Ollama models are now driven by OllamaStateManager)
     providerModels: {
         local: ['gemma-9b', 'llama-8b', 'llama-3b', 'auto'],
-        deepseek: ['deepseek-chat', 'deepseek-coder'],
+        // #325: deepseek-chat/-reasoner deprecate 2026-07-24; v4 names per
+        // https://api-docs.deepseek.com/ (flash = non-thinking, pro = thinking)
+        deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro'],
         gemini: ['gemini-2.0-flash', 'gemini-1.5-flash', 'gemini-1.5-pro'],
         claude: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022', 'claude-3-opus-20240229'],
         gpt: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
@@ -7180,7 +7184,9 @@ const TranslationSettingsModal = {
     // Provider model options (Ollama models are now driven by OllamaStateManager)
     providerModels: {
         local: ['gemma-9b', 'llama-8b', 'llama-3b', 'auto'],
-        deepseek: ['deepseek-chat', 'deepseek-coder'],
+        // #325: deepseek-chat/-reasoner deprecate 2026-07-24; v4 names per
+        // https://api-docs.deepseek.com/ (flash = non-thinking, pro = thinking)
+        deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro'],
         gemini: ['gemini-2.0-flash', 'gemini-1.5-flash', 'gemini-1.5-pro'],
         claude: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022', 'claude-3-opus-20240229'],
         gpt: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
@@ -7470,15 +7476,77 @@ const TranslationSettingsModal = {
 // GUI Settings Persistence
 // ============================================================
 const SettingsPersistence = {
-    // Disabled: Tab 1 + Tab 3 always start from HTML defaults.
-    // Backend module (gui_settings.py) retained for future "exit prompt" feature.
-    // Preset CRUD (EnsembleManager) is unaffected.
-    init() {},
-    collectAll() { return {}; },
-    applyToForm() {},
-    async loadFromBackend() {},
-    scheduleSave() {},
-    async _doSave() {},
+    // v1.9.0 (#96/#298): OPT-IN persistence for Tab 1 form fields.
+    FIELDS: {
+        'mode':             { key: 'mode',           prop: 'value' },
+        'sensitivity':      { key: 'sensitivity',    prop: 'value' },
+        'source-language':  { key: 'sourceLanguage', prop: 'value' },
+        'language':         { key: 'subsLanguage',   prop: 'value' },
+        'outputDir':        { key: 'outputDir',      prop: 'value' },
+        'outputFormat':     { key: 'outputFormat',   prop: 'value' },
+        'tempDir':          { key: 'tempDir',        prop: 'value' },
+        'debugLogging':     { key: 'debugLogging',   prop: 'checked' },
+        'keepTemp':         { key: 'keepTemp',       prop: 'checked' },
+        'skipExisting':     { key: 'skipExisting',   prop: 'checked' },
+        'acceptCpuMode':    { key: 'acceptCpuMode',  prop: 'checked' },
+    },
+    _saveTimer: null,
+    enabled: false,
+    init() {
+        const toggle = document.getElementById('rememberSettings');
+        if (!toggle) return;
+        toggle.addEventListener('change', () => {
+            this.enabled = toggle.checked;
+            this._doSave();
+        });
+        for (const id of Object.keys(this.FIELDS)) {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener('change', () => this.scheduleSave());
+        }
+    },
+    collectAll() {
+        const out = { rememberSettings: this.enabled };
+        if (!this.enabled) return out;
+        for (const [id, spec] of Object.entries(this.FIELDS)) {
+            const el = document.getElementById(id);
+            if (el) out[spec.key] = el[spec.prop];
+        }
+        return out;
+    },
+    applyToForm(settings) {
+        for (const [id, spec] of Object.entries(this.FIELDS)) {
+            if (!(spec.key in settings)) continue;
+            const el = document.getElementById(id);
+            if (!el) continue;
+            el[spec.prop] = settings[spec.key];
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+    },
+    async loadFromBackend() {
+        try {
+            const res = await pywebview.api.get_gui_settings();
+            if (!res || !res.success) return;
+            const settings = res.settings || {};
+            const toggle = document.getElementById('rememberSettings');
+            this.enabled = !!settings.rememberSettings;
+            if (toggle) toggle.checked = this.enabled;
+            if (this.enabled) this.applyToForm(settings);
+        } catch (e) {
+            console.warn('Failed to load GUI settings:', e);
+        }
+    },
+    scheduleSave() {
+        if (!this.enabled) return;
+        clearTimeout(this._saveTimer);
+        this._saveTimer = setTimeout(() => this._doSave(), 500);
+    },
+    async _doSave() {
+        try {
+            await pywebview.api.save_gui_settings(this.collectAll());
+        } catch (e) {
+            console.warn('Failed to save GUI settings:', e);
+        }
+    },
     async restorePresets() {},
 };
 
@@ -7508,6 +7576,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     TranslatorManager.init();
     TranslateIntegrationManager.init();
     TranslationSettingsModal.init();
+    SettingsPersistence.init();
 
     // Initial validation
     FormManager.validateForm();
@@ -7561,6 +7630,8 @@ window.addEventListener('pywebviewready', async () => {
 
     // Tab 4 translation settings (unaffected by persistence removal)
     await TranslationSettingsModal.loadSettingsFromBackend();
+
+    await SettingsPersistence.loadFromBackend();
 
     // Restore saved provider selections from localStorage
     const savedEnsemble = localStorage.getItem('whisperjav_ensemble_provider');

--- a/whisperjav/webview_gui/assets/index.html
+++ b/whisperjav/webview_gui/assets/index.html
@@ -331,6 +331,18 @@
                                         <span>Keep temp files</span>
                                     </label>
                                 </div>
+                                <div class="form-group">
+                                    <label class="checkbox-label" title="Skip files that already have a WhisperJAV subtitle in the output folder">
+                                        <input type="checkbox" id="skipExisting">
+                                        <span>Skip already-subtitled files</span>
+                                    </label>
+                                </div>
+                                <div class="form-group">
+                                    <label class="checkbox-label" title="Restore these form settings the next time WhisperJAV starts">
+                                        <input type="checkbox" id="rememberSettings">
+                                        <span>Remember settings</span>
+                                    </label>
+                                </div>
                                 <div class="form-group temp-dir-group inline-field">
                                     <label for="tempDir" class="form-label" style="white-space: nowrap;">Temp dir:</label>
                                     <div class="input-with-button">


### PR DESCRIPTION
Last of four related PRs (see #375 for context). Four small user-facing items:

1. **#328** - `--skip-existing` shipped in v1.8.14 for CLI sync/async but
   not ensemble mode and not the GUI. Adds the ensemble-path filter
   (checks `<basename>.<lang>.merged.whisperjav.srt`) and a "Skip
   already-subtitled files" checkbox wired through all arg builders.

2. **#96 / #298** - Tab-1 settings persistence, OPT-IN via a "Remember
   settings" checkbox (default off), so the deliberate start-from-defaults
   behavior is unchanged unless the user asks. Uses the existing
   `gui_settings.py` backend.

3. **#309** - preset/settings saves replace `unlink()+rename()` with
   `os.replace` (atomic, no missing-target window) plus a direct-write
   fallback on OSError; the settings path is `resolve()`d so mklink'd
   %APPDATA% junctions collapse before writes. Should address the Save
   Preset failure reported there.

4. **#325** - the backend default was fixed in v1.8.14 (f234610), but both
   GUI providerModels maps still offered deepseek-chat/deepseek-coder,
   which deprecate 2026-07-24. Now deepseek-v4-flash / deepseek-v4-pro.

Updates the settings-count guard test (29 -> 31 keys). No behavior changes
unless the new checkboxes are used.